### PR TITLE
fix: folder duplication, dead-session recovery, first-party email images

### DIFF
--- a/src/contexts/auth/auth_provider.tsx
+++ b/src/contexts/auth/auth_provider.tsx
@@ -297,14 +297,35 @@ export function AuthProvider({ children }: AuthProviderProps) {
           api_client.clear_auth_data();
           api_client.set_authenticated(false);
           sync_client.disconnect();
+
+          try {
+            await storage_remove_account(current.id);
+            clear_stored_encrypted_vault(current.id);
+            await clear_session_passphrase(current.id);
+            clear_session_timeout_data(current.id);
+          } catch (e) {
+            safe_log_error(e);
+          }
+
+          const remaining = await get_all_accounts();
+          const local = current.user.email.split("@")[0] ?? "";
+
           set_state({
             user: null,
             is_loading: false,
             is_authenticated: false,
             has_keys: false,
-            accounts: data.accounts,
-            current_account_id: data.current_account_id,
+            accounts: remaining,
+            current_account_id: remaining[0]?.id ?? null,
           });
+
+          const uses_hash = "__TAURI_INTERNALS__" in window;
+          const path = uses_hash
+            ? window.location.hash.slice(1).split("?")[0] || "/"
+            : window.location.pathname;
+          if (path !== "/sign-in" && path !== "/register") {
+            navigate(`/sign-in?u=${encodeURIComponent(local)}`);
+          }
         }
       } catch (e) {
         safe_log_error(e);

--- a/src/hooks/use_folders.ts
+++ b/src/hooks/use_folders.ts
@@ -86,6 +86,19 @@ export interface FolderTreeNode {
   depth: number;
 }
 
+const SYSTEM_FOLDER_TYPES = new Set([
+  "inbox",
+  "sent",
+  "drafts",
+  "trash",
+  "spam",
+  "archive",
+]);
+
+export function is_system_folder_type(folder_type: string | undefined): boolean {
+  return folder_type !== undefined && SYSTEM_FOLDER_TYPES.has(folder_type);
+}
+
 export function build_folder_tree(
   folders: DecryptedFolder[],
 ): FolderTreeNode[] {
@@ -411,7 +424,8 @@ async function decrypt_folder(
     name,
     color,
     icon,
-    is_system: folder.is_system,
+    is_system:
+      folder.is_system || is_system_folder_type(folder.folder_type ?? "custom"),
     is_locked: folder.is_locked ?? false,
     folder_type: folder.folder_type ?? "custom",
     is_password_protected: folder.is_password_protected ?? false,

--- a/src/lib/html_sanitizer.ts
+++ b/src/lib/html_sanitizer.ts
@@ -473,7 +473,17 @@ export function sanitize_html(
       const is_data_url = lower_src.startsWith("data:");
       const is_pixel = is_tracking_pixel(new_element as HTMLImageElement);
 
-      if (is_remote && src.startsWith("http://")) {
+      let is_first_party = false;
+
+      if (is_remote && typeof window !== "undefined") {
+        try {
+          is_first_party = new URL(src).origin === window.location.origin;
+        } catch {
+          is_first_party = false;
+        }
+      }
+
+      if (is_remote && !is_first_party && src.startsWith("http://")) {
         src = "https://" + src.slice(7);
         new_element.setAttribute("src", src);
       }
@@ -493,7 +503,7 @@ export function sanitize_html(
         }
       }
 
-      if (is_remote) {
+      if (is_remote && !is_first_party) {
         external_content.has_remote_images = true;
         if (is_pixel) {
           external_content.has_tracking_pixels = true;

--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -405,17 +405,9 @@ class ApiClient {
       this.schedule_token_refresh();
     } else {
       this.is_authenticated_flag = false;
-      this.dev_access_token = null;
       clear_csrf_cache();
-      if ((Capacitor.isNativePlatform() || is_tauri_env()) && has_stored_token) {
-        this.clear_native_token();
-        if (is_tauri_env()) {
-          try {
-            localStorage.removeItem(TAURI_TOKEN_KEY);
-            localStorage.removeItem(TAURI_CSRF_KEY);
-          } catch {}
-        }
-      } else {
+      this.clear_dev_token();
+      if (!Capacitor.isNativePlatform() && !is_tauri_env()) {
         try {
           await this.clear_session_cookies();
         } catch {}
@@ -682,6 +674,7 @@ class ApiClient {
             me_response.code === "UNAUTHORIZED" ||
             me_response.code === "FORBIDDEN"
           ) {
+            this.is_authenticated_flag = false;
             this.dispatch_session_expired();
 
             return;


### PR DESCRIPTION
Three isolated fixes, branched off `main` (no migrations required):

1. **Folders** - default mailbox folders (Inbox/Sent/Drafts/Trash/Spam/Archive) could persist with `is_system=false` and render in the user FOLDERS list, duplicating the built-in MAIL/MORE views. Derive `is_system` from the folder type. Pairs with Aster-Backend PR #7 (server-side fix for newly created folders).
2. **Auth** - a definitively invalid stored session (401/403) could leave the app on a blank loading state instead of the sign-in screen. Mark unauthenticated, clear the stored token, drop the dead account, route to sign-in. Only fires on definitive auth failure (not transient), consistent with the existing session-expired handler.
3. **Email images** - first-party images (same origin as the app) load directly instead of being needlessly routed through the image proxy.

Verified: tsc clean on all changed files; no schema changes.