### PR TITLE
test(a11y): add playwright config for axe accessibility scan

### DIFF
--- a/playwright.config.a11y.ts
+++ b/playwright.config.a11y.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./playwright",
+  testMatch: ["a11y_scan.spec.ts"],
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [["list"]],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: "http://localhost:5173",
+    bypassCSP: true,
+    trace: "off",
+    screenshot: "off",
+    video: "off",
+  },
+  webServer: {
+    command: "npx vite --port 5173 --strictPort",
+    url: "http://localhost:5173",
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
Adds the playwright a11y config that the existing test:a11y script references. Scans public routes with axe-core against a local dev server.