### PR TITLE
Security: authenticate ratchet prekey bundles; strip remote CSS from preview

### DIFF
--- a/src/components/email/sandboxed_email_renderer.tsx
+++ b/src/components/email/sandboxed_email_renderer.tsx
@@ -38,6 +38,19 @@ import { is_any_lockdown_active } from "@/services/lockdown_store";
 
 const IMAGE_PROXY_URL = get_image_proxy_url();
 
+/*
+ * Mirror of strip_remote_css_fetches in hooks/preload_cache.ts. The live
+ * preview renders sandbox-mode HTML (which keeps <style> blocks and remote
+ * url()/@import) into a top-origin shadow root, so neutralize remote CSS
+ * fetches to stop tracking beacons. The real render happens in the sandboxed
+ * iframe, which honors the remote-content setting, so display is unaffected.
+ */
+function strip_remote_css_fetches(html: string): string {
+  return html
+    .replace(/url\(\s*(['"]?)https?:\/\/[^)]*\1\s*\)/gi, "url()")
+    .replace(/@import[^;]*;/gi, "");
+}
+
 function sniff_image_type(bytes: Uint8Array): string | null {
   if (bytes.length >= 4) {
     if (bytes[0] === 0x89 && bytes[1] === 0x50 && bytes[2] === 0x4e && bytes[3] === 0x47)
@@ -1098,7 +1111,7 @@ ${dark_mode_css ? `<style>${dark_mode_css}</style>` : ""}
         `<style>${EMAIL_BODY_CSS}` +
         (dark_mode_css ? dark_mode_css : "") +
         `a{pointer-events:none}</style>` +
-        `<div style="${body_style}">${resolved_html}</div>`;
+        `<div style="${body_style}">${strip_remote_css_fetches(resolved_html)}</div>`;
     },
     [
       resolved_html,

--- a/src/services/crypto/key_manager_pgp.ts
+++ b/src/services/crypto/key_manager_pgp.ts
@@ -357,6 +357,100 @@ export async function verify_key_binding(
   };
 }
 
+const RATCHET_PREKEY_SIG_PREFIX = "aster-ratchet-prekey-v1:";
+const PGP_CLEARTEXT_HEADER = "-----BEGIN PGP SIGNED MESSAGE-----";
+
+function build_ratchet_prekey_canonical(
+  kem_identity_key: string,
+  signed_prekey: string,
+): string {
+  return `${RATCHET_PREKEY_SIG_PREFIX}${kem_identity_key}.${signed_prekey}`;
+}
+
+/*
+ * Produce a real OpenPGP cleartext signature binding the ratchet identity key
+ * and signed prekey to the user's long-term PGP identity key. The armored
+ * signature is base64-wrapped so it survives the prekey-bundle endpoint, which
+ * stores the field as opaque bytes. Throws on failure; the caller falls back to
+ * the legacy hash binding so prekey upload never breaks.
+ */
+export async function sign_ratchet_prekey_bundle(
+  identity_secret_key: string,
+  passphrase: string,
+  kem_identity_key: string,
+  signed_prekey: string,
+): Promise<string> {
+  const identity_key = await openpgp.decryptKey({
+    ["privateKey" as const]: await openpgp.readPrivateKey({
+      armoredKey: identity_secret_key,
+    }),
+    passphrase,
+  });
+
+  const text = build_ratchet_prekey_canonical(kem_identity_key, signed_prekey);
+  const message = await openpgp.createCleartextMessage({ text });
+  const signed = await openpgp.sign({
+    message,
+    signingKeys: identity_key,
+    format: "armored",
+  });
+
+  const armored = String(signed);
+
+  return array_to_base64(new TextEncoder().encode(armored));
+}
+
+export type RatchetPrekeyVerdict =
+  | "verified"
+  | "tampered"
+  | "legacy"
+  | "unknown";
+
+/*
+ * Verify a fetched ratchet prekey bundle's signature against the bundle owner's
+ * PGP identity public key. Returns "tampered" ONLY when the field is a genuine
+ * PGP signature that fails to verify for the supplied keys - the single case in
+ * which the caller refuses the ratchet bootstrap. Every other outcome (a legacy
+ * hash, an unreadable field, a missing owner key, or any error) returns a
+ * non-rejecting verdict so legitimate mail is never blocked.
+ */
+export async function verify_ratchet_prekey_bundle(
+  signature_field: string,
+  kem_identity_key: string,
+  signed_prekey: string,
+  owner_pgp_public_key: string | null,
+): Promise<RatchetPrekeyVerdict> {
+  let armored: string;
+
+  try {
+    armored = new TextDecoder().decode(base64_to_array(signature_field));
+  } catch {
+    return "unknown";
+  }
+
+  if (!armored.startsWith(PGP_CLEARTEXT_HEADER)) {
+    return "legacy";
+  }
+
+  if (!owner_pgp_public_key) {
+    return "unknown";
+  }
+
+  const text = build_ratchet_prekey_canonical(kem_identity_key, signed_prekey);
+
+  try {
+    const ok = await verify_prekey_signature(
+      text,
+      armored,
+      owner_pgp_public_key,
+    );
+
+    return ok ? "verified" : "tampered";
+  } catch {
+    return "unknown";
+  }
+}
+
 export function generate_recovery_codes(count: number = 6): string[] {
   const codes: string[] = [];
   const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";

--- a/src/services/crypto/ratchet_manager.ts
+++ b/src/services/crypto/ratchet_manager.ts
@@ -26,6 +26,7 @@ const _KE = ["EC", "DH"].join("");
 const _KC = ["P", "256"].join("-");
 
 import { api_client } from "../api/client";
+import { get_recipient_public_key } from "../api/keys";
 
 import {
   DoubleRatchet,
@@ -43,7 +44,14 @@ import {
   sync_ratchet_to_server,
   derive_ratchet_encryption_key,
 } from "./ratchet_sync";
-import { get_derived_encryption_key } from "./memory_key_store";
+import {
+  get_derived_encryption_key,
+  get_passphrase_from_memory,
+} from "./memory_key_store";
+import {
+  sign_ratchet_prekey_bundle,
+  verify_ratchet_prekey_bundle,
+} from "./key_manager_pgp";
 import {
   get_cached_ratchet_plaintext,
   set_cached_ratchet_plaintext,
@@ -177,6 +185,18 @@ async function fetch_prekey_bundle(
   return response.data;
 }
 
+async function legacy_prekey_signature(
+  identity_public: string,
+  signed_prekey_public: string,
+): Promise<string> {
+  const signature_input = new TextEncoder().encode(
+    identity_public + signed_prekey_public,
+  );
+  const signature_hash = await crypto.subtle.digest(HASH_ALG, signature_input);
+
+  return array_to_base64(new Uint8Array(signature_hash));
+}
+
 export async function upload_prekey_bundle(
   vault: EncryptedVault,
 ): Promise<boolean> {
@@ -184,11 +204,29 @@ export async function upload_prekey_bundle(
     return false;
   }
 
-  const signature_input = new TextEncoder().encode(
-    vault.ratchet_identity_public + vault.ratchet_signed_prekey_public,
-  );
-  const signature_hash = await crypto.subtle.digest(HASH_ALG, signature_input);
-  const signature = array_to_base64(new Uint8Array(signature_hash));
+  const passphrase = get_passphrase_from_memory();
+  let signature: string;
+
+  if (vault.identity_key && passphrase) {
+    try {
+      signature = await sign_ratchet_prekey_bundle(
+        vault.identity_key,
+        passphrase,
+        vault.ratchet_identity_public,
+        vault.ratchet_signed_prekey_public,
+      );
+    } catch {
+      signature = await legacy_prekey_signature(
+        vault.ratchet_identity_public,
+        vault.ratchet_signed_prekey_public,
+      );
+    }
+  } else {
+    signature = await legacy_prekey_signature(
+      vault.ratchet_identity_public,
+      vault.ratchet_signed_prekey_public,
+    );
+  }
 
   const response = await api_client.put("/crypto/v1/ratchet/prekey-bundle", {
     kem_identity_key: vault.ratchet_identity_public,
@@ -257,6 +295,27 @@ export async function encrypt_for_ratchet_recipient(
         (recipient_email ?? recipient_username).toLowerCase(),
         bundle.kem_identity_key,
       );
+
+      const owner_key = await get_recipient_public_key(
+        recipient_username,
+        recipient_email,
+      );
+      const bundle_verdict = await verify_ratchet_prekey_bundle(
+        bundle.signed_prekey_signature,
+        bundle.kem_identity_key,
+        bundle.signed_prekey,
+        owner_key.data?.public_key ?? null,
+      );
+
+      if (bundle_verdict === "tampered") {
+        if (import.meta.env.DEV) {
+          console.warn(
+            "ratchet prekey bundle signature failed verification; routing via PGP",
+          );
+        }
+
+        return null;
+      }
 
       const sender_identity_jwk: JsonWebKey = JSON.parse(
         vault.ratchet_identity_key,

--- a/src/services/crypto/ratchet_prekey_signature.test.ts
+++ b/src/services/crypto/ratchet_prekey_signature.test.ts
@@ -1,0 +1,184 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, beforeAll } from "vitest";
+import * as openpgp from "openpgp";
+
+import {
+  sign_ratchet_prekey_bundle,
+  verify_ratchet_prekey_bundle,
+} from "./key_manager_pgp";
+import { array_to_base64 } from "./key_manager_core";
+
+const PASSPHRASE = "correct horse battery staple";
+
+const KEM_IDENTITY = array_to_base64(new Uint8Array(65).fill(7));
+const SIGNED_PREKEY = array_to_base64(new Uint8Array(65).fill(9));
+
+let owner_private = "";
+let owner_public = "";
+let attacker_public = "";
+
+async function generate_pgp(): Promise<{ privateKey: string; publicKey: string }> {
+  const { privateKey, publicKey } = await openpgp.generateKey({
+    type: "ecc",
+    curve: "ed25519Legacy",
+    userIDs: [{ name: "Test", email: "test@astermail.org" }],
+    passphrase: PASSPHRASE,
+    format: "armored",
+  });
+
+  return { privateKey, publicKey };
+}
+
+beforeAll(async () => {
+  const owner = await generate_pgp();
+  owner_private = owner.privateKey;
+  owner_public = owner.publicKey;
+
+  const attacker = await generate_pgp();
+  attacker_public = attacker.publicKey;
+}, 60000);
+
+describe("ratchet prekey bundle signature", () => {
+  it("round-trips: a freshly signed bundle verifies as 'verified'", async () => {
+    const field = await sign_ratchet_prekey_bundle(
+      owner_private,
+      PASSPHRASE,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+    );
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      field,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+      owner_public,
+    );
+
+    expect(verdict).toBe("verified");
+  });
+
+  it("flags a swapped identity key as 'tampered'", async () => {
+    const field = await sign_ratchet_prekey_bundle(
+      owner_private,
+      PASSPHRASE,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+    );
+
+    const swapped_kem = array_to_base64(new Uint8Array(65).fill(42));
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      field,
+      swapped_kem,
+      SIGNED_PREKEY,
+      owner_public,
+    );
+
+    expect(verdict).toBe("tampered");
+  });
+
+  it("flags a swapped signed prekey as 'tampered'", async () => {
+    const field = await sign_ratchet_prekey_bundle(
+      owner_private,
+      PASSPHRASE,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+    );
+
+    const swapped_spk = array_to_base64(new Uint8Array(65).fill(42));
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      field,
+      KEM_IDENTITY,
+      swapped_spk,
+      owner_public,
+    );
+
+    expect(verdict).toBe("tampered");
+  });
+
+  it("flags a valid signature from the wrong identity key as 'tampered'", async () => {
+    const field = await sign_ratchet_prekey_bundle(
+      owner_private,
+      PASSPHRASE,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+    );
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      field,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+      attacker_public,
+    );
+
+    expect(verdict).toBe("tampered");
+  });
+
+  it("treats a legacy hash signature field as 'legacy' (non-rejecting)", async () => {
+    const input = new TextEncoder().encode(KEM_IDENTITY + SIGNED_PREKEY);
+    const hash = await crypto.subtle.digest("SHA-256", input);
+    const legacy_field = array_to_base64(new Uint8Array(hash));
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      legacy_field,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+      owner_public,
+    );
+
+    expect(verdict).toBe("legacy");
+  });
+
+  it("returns 'unknown' (non-rejecting) when the owner key is unavailable", async () => {
+    const field = await sign_ratchet_prekey_bundle(
+      owner_private,
+      PASSPHRASE,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+    );
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      field,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+      null,
+    );
+
+    expect(verdict).toBe("unknown");
+  });
+
+  it("never returns 'tampered' for a legacy bundle even with a wrong key", async () => {
+    const input = new TextEncoder().encode(KEM_IDENTITY + SIGNED_PREKEY);
+    const hash = await crypto.subtle.digest("SHA-256", input);
+    const legacy_field = array_to_base64(new Uint8Array(hash));
+
+    const verdict = await verify_ratchet_prekey_bundle(
+      legacy_field,
+      KEM_IDENTITY,
+      SIGNED_PREKEY,
+      attacker_public,
+    );
+
+    expect(verdict).toBe("legacy");
+  });
+});


### PR DESCRIPTION
Two frontend security fixes from a vulnerability sweep. Backward-compatible and fail-safe; verified with tsc (no new errors) and the crypto test suite (246 pass, including 7 new tests).

### crypto: authenticate ratchet prekey bundles
The prekey bundle's `signed_prekey_signature` was a SHA-256 of public key material (no authentication) and was never verified, allowing a malicious server to substitute keys and MITM internal E2E mail.

- Upload now produces a real OpenPGP signature over the ratchet identity + signed prekey, bound to the user's PGP identity key. Best-effort with fallback to the prior hash, so upload never fails.
- On bootstrap, the bundle signature is verified against the recipient's PGP key. A definitive mismatch refuses the ratchet bootstrap and returns null, which fail-safe routes the message through the existing PGP path (never dropped, never plaintext). Legacy bundles, missing keys, and errors proceed unchanged, so mixed-version fleets keep working.
- No backend change: the signature rides through the existing field as base64-wrapped bytes.

This is phase 1 (authentication + verification). Enforcement (requiring a valid signature once the fleet has adopted, plus an out-of-band trust anchor) is a separate follow-up.

### email: strip remote CSS from preview
The live preview rendered sandbox-mode HTML into a top-origin shadow DOM without stripping remote CSS, letting a crafted message beacon out via `url()`/`@import`. Apply the same `strip_remote_css_fetches` the height-measure path already uses. The real render in the sandboxed iframe is unchanged.