### PR TITLE
Enable CDN relay connection option

### DIFF
--- a/src/services/routing/tor_transport.ts
+++ b/src/services/routing/tor_transport.ts
@@ -71,7 +71,7 @@ export function is_snowflake_supported(): boolean {
 }
 
 export function is_cdn_relay_supported(): boolean {
-  return false;
+  return true;
 }
 
 function start_tor_status_polling(): void {


### PR DESCRIPTION
Re-enables the CDN relay connection option in the client. It was hidden in 5eb8e59 pending the relay rollout; the relay is now live and proxying correctly (relay.astermail.org and relay.aster.cx return 200 for /api/core/v1/connection-info on browser and native flows).

This flips `is_cdn_relay_supported()` back to true. The filter added by the hide commit then surfaces the option on desktop, mobile, and web. No other change needed: the transport (cdn_relay_transport) already uses the native proxy on Tauri (the earlier CORS fix), browser fetch on web, and the worker permits mobile via the x-aster-client native-client allowance. It fails closed (never silently downgrades to clearnet) when no relay URL is available.

Depends on the backend advertising CDN_RELAY_URLS via /core/v1/connection-info (handled separately); until then the client safely falls back rather than breaking.

Verified: tsc adds zero errors (measured base vs branch, both 93 pre-existing on main). Routing dispatch reviewed for all three platforms.