### PR TITLE
fix(auth): reliable 2FA code entry and passkey retry

### DIFF
--- a/src/components/auth/backup_code_input.test.tsx
+++ b/src/components/auth/backup_code_input.test.tsx
@@ -1,0 +1,194 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { BackupCodeInput } from "./backup_code_input";
+import { verify_backup_code_login } from "@/services/api/totp";
+
+vi.mock("@/services/api/totp", () => ({
+  verify_backup_code_login: vi.fn(),
+}));
+
+vi.mock("@/lib/i18n/context", () => ({
+  use_i18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@aster/ui", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: unknown;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children as never}
+    </button>
+  ),
+}));
+
+const mocked_verify = vi.mocked(verify_backup_code_login);
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const native_value_setter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  "value",
+)!.set!;
+
+describe("BackupCodeInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const props = () => ({
+    pending_login_token: "pending-token",
+    on_success: vi.fn(),
+    on_use_authenticator: vi.fn(),
+    on_cancel: vi.fn(),
+  });
+
+  const text_input = () =>
+    container.querySelector("input") as HTMLInputElement;
+
+  const submit_button = () =>
+    Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("common.continue"),
+    ) as HTMLButtonElement;
+
+  const type_code = async (value: string) => {
+    const input = text_input();
+
+    await act(async () => {
+      native_value_setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+
+  const render = async (overrides = {}) => {
+    const p = { ...props(), ...overrides };
+
+    await act(async () => {
+      root.render(<BackupCodeInput {...p} />);
+    });
+
+    return p;
+  };
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocked_verify.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("keeps submit disabled until 12 alphanumeric characters are present", async () => {
+    await render();
+
+    await type_code("ABCD-EFGH");
+    expect(submit_button().disabled).toBe(true);
+
+    await type_code("ABCD-EFGH-JKMN");
+    expect(submit_button().disabled).toBe(false);
+  });
+
+  it("normalizes and dash-formats the code before sending", async () => {
+    mocked_verify.mockResolvedValue({ data: undefined, error: "x" });
+    await render();
+
+    await type_code("abcdefghjkmn");
+    await act(async () => {
+      submit_button().click();
+    });
+
+    expect(mocked_verify).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "ABCD-EFGH-JKMN" }),
+    );
+  });
+
+  it("calls on_success when the code is accepted", async () => {
+    mocked_verify.mockResolvedValue({
+      data: {
+        user_id: "u1",
+        username: "fate",
+        email: "fate@aster.cx",
+        csrf_token: "c",
+        encrypted_vault: "v",
+        vault_nonce: "n",
+      },
+    });
+    const p = await render();
+
+    await type_code("ABCD-EFGH-JKMN");
+    await act(async () => {
+      submit_button().click();
+    });
+
+    expect(p.on_success).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the code and shows the error on failure", async () => {
+    mocked_verify.mockResolvedValue({ data: undefined, error: "Invalid backup code" });
+    await render();
+
+    await type_code("ABCD-EFGH-JKMN");
+    await act(async () => {
+      submit_button().click();
+    });
+
+    expect(text_input().value).toBe("ABCD-EFGH-JKMN");
+    expect(container.textContent).toContain("Invalid backup code");
+  });
+
+  it("ignores a second submit while one is already in flight", async () => {
+    mocked_verify.mockReturnValue(new Promise(() => {}));
+    await render();
+
+    await type_code("ABCD-EFGH-JKMN");
+
+    await act(async () => {
+      const input = text_input();
+      const enter = () =>
+        input.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+        );
+
+      enter();
+      enter();
+    });
+
+    expect(mocked_verify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/auth/backup_code_input.tsx
+++ b/src/components/auth/backup_code_input.tsx
@@ -48,12 +48,15 @@ export function BackupCodeInput({
   const [is_loading, set_is_loading] = useState(false);
   const [error, set_error] = useState("");
   const input_ref = useRef<HTMLInputElement>(null);
+  const verifying_ref = useRef(false);
 
   useEffect(() => {
     input_ref.current?.focus();
   }, []);
 
   const handle_verify = async () => {
+    if (verifying_ref.current) return;
+
     const normalized = code.toUpperCase().replace(/[^A-Z0-9]/g, "");
 
     if (normalized.length !== 12) {
@@ -62,6 +65,7 @@ export function BackupCodeInput({
       return;
     }
 
+    verifying_ref.current = true;
     set_is_loading(true);
     set_error("");
 
@@ -75,18 +79,22 @@ export function BackupCodeInput({
 
     if (response.error) {
       set_error(response.error);
+      verifying_ref.current = false;
       set_is_loading(false);
+      input_ref.current?.focus();
 
       return;
     }
 
     if (response.data) {
+      verifying_ref.current = false;
       set_is_loading(false);
       on_success(response.data);
 
       return;
     }
 
+    verifying_ref.current = false;
     set_is_loading(false);
   };
 

--- a/src/components/auth/totp_verification.test.tsx
+++ b/src/components/auth/totp_verification.test.tsx
@@ -1,0 +1,240 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { TotpVerification } from "./totp_verification";
+import { verify_totp_login } from "@/services/api/totp";
+
+vi.mock("@/services/api/totp", () => ({
+  verify_totp_login: vi.fn(),
+}));
+
+vi.mock("@/lib/i18n/context", () => ({
+  use_i18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@aster/ui", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: unknown;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children as never}
+    </button>
+  ),
+  Checkbox: (props: Record<string, unknown>) => (
+    <input type="checkbox" {...(props as object)} />
+  ),
+}));
+
+const mocked_verify = vi.mocked(verify_totp_login);
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const native_value_setter = Object.getOwnPropertyDescriptor(
+  window.HTMLInputElement.prototype,
+  "value",
+)!.set!;
+
+describe("TotpVerification", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const props = () => ({
+    pending_login_token: "pending-token",
+    on_success: vi.fn(),
+    on_use_backup_code: vi.fn(),
+    on_cancel: vi.fn(),
+  });
+
+  const code_input = () =>
+    container.querySelector(
+      'input[inputmode="numeric"]',
+    ) as HTMLInputElement;
+
+  const verify_button = () =>
+    Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("common.continue"),
+    ) as HTMLButtonElement;
+
+  const type_code = async (value: string) => {
+    const input = code_input();
+
+    await act(async () => {
+      native_value_setter.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+  };
+
+  const press_enter = async () => {
+    await act(async () => {
+      code_input().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+  };
+
+  const render = async (overrides = {}) => {
+    const p = { ...props(), ...overrides };
+
+    await act(async () => {
+      root.render(<TotpVerification {...p} />);
+    });
+
+    return p;
+  };
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocked_verify.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("renders a single text input, not a numeric type", async () => {
+    await render();
+    const input = code_input();
+
+    expect(input).toBeTruthy();
+    expect(input.getAttribute("type")).toBe("text");
+    expect(container.querySelectorAll('input[inputmode="numeric"]').length).toBe(
+      1,
+    );
+  });
+
+  it("strips non-digits and caps the code at 6 characters", async () => {
+    await render();
+    await type_code("12ab34cd5678");
+
+    expect(code_input().value).toBe("123456");
+  });
+
+  it("keeps the verify button disabled until exactly 6 digits", async () => {
+    await render();
+
+    await type_code("12345");
+    expect(verify_button().disabled).toBe(true);
+
+    await type_code("123456");
+    expect(verify_button().disabled).toBe(false);
+  });
+
+  it("does not auto-submit; verify is only called on explicit submit", async () => {
+    mocked_verify.mockResolvedValue({ data: undefined, error: "nope" });
+    await render();
+
+    await type_code("123456");
+    expect(mocked_verify).not.toHaveBeenCalled();
+
+    await act(async () => {
+      verify_button().click();
+    });
+    expect(mocked_verify).toHaveBeenCalledTimes(1);
+    expect(mocked_verify).toHaveBeenCalledWith(
+      expect.objectContaining({ code: "123456", pending_login_token: "pending-token" }),
+    );
+  });
+
+  it("keeps the entered code and shows an error on failure (no auto-clear)", async () => {
+    mocked_verify.mockResolvedValue({
+      data: undefined,
+      error: "Invalid verification code",
+    });
+    await render();
+
+    await type_code("000123");
+    await act(async () => {
+      verify_button().click();
+    });
+
+    expect(code_input().value).toBe("000123");
+    expect(container.textContent).toContain("Invalid verification code");
+  });
+
+  it("calls on_success when verification succeeds", async () => {
+    mocked_verify.mockResolvedValue({
+      data: {
+        user_id: "u1",
+        username: "fate",
+        email: "fate@aster.cx",
+        csrf_token: "c",
+        encrypted_vault: "v",
+        vault_nonce: "n",
+      },
+    });
+    const p = await render();
+
+    await type_code("654321");
+    await act(async () => {
+      verify_button().click();
+    });
+
+    expect(p.on_success).toHaveBeenCalledTimes(1);
+  });
+
+  it("submits on Enter", async () => {
+    mocked_verify.mockResolvedValue({ data: undefined, error: "x" });
+    await render();
+
+    await type_code("111111");
+    await press_enter();
+
+    expect(mocked_verify).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a second submit while one is already in flight", async () => {
+    mocked_verify.mockReturnValue(new Promise(() => {}));
+    await render();
+
+    await type_code("222222");
+
+    await act(async () => {
+      const input = code_input();
+      const enter = () =>
+        input.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+        );
+
+      enter();
+      enter();
+    });
+
+    expect(mocked_verify).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/auth/totp_verification.tsx
+++ b/src/components/auth/totp_verification.tsx
@@ -18,12 +18,14 @@
 // You should have received a copy of the AGPLv3
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Button, Checkbox } from "@aster/ui";
 
 import { Input } from "@/components/ui/input";
 import { use_i18n } from "@/lib/i18n/context";
 import { verify_totp_login, TotpVerifyResponse } from "@/services/api/totp";
+
+const TOTP_CODE_LENGTH = 6;
 
 interface TotpVerificationProps {
   pending_login_token: string;
@@ -47,18 +49,18 @@ export function TotpVerification({
   const [is_loading, set_is_loading] = useState(false);
   const [error, set_error] = useState("");
   const [trust_device, set_trust_device] = useState(false);
-  const input_refs = useRef<(HTMLInputElement | null)[]>([]);
+  const input_ref = useRef<HTMLInputElement>(null);
+  const verifying_ref = useRef(false);
 
-  const handle_verify_ref = useRef<((c: string) => Promise<void>) | null>(null);
+  const handle_verify = async () => {
+    if (code.length !== TOTP_CODE_LENGTH || verifying_ref.current) return;
 
-  const handle_verify = useCallback(async (current_code: string) => {
-    if (current_code.length !== 6) return;
-
+    verifying_ref.current = true;
     set_is_loading(true);
     set_error("");
 
     const response = await verify_totp_login({
-      code: current_code,
+      code,
       pending_login_token,
       trust_device,
       remember_me,
@@ -66,76 +68,37 @@ export function TotpVerification({
 
     if (response.error) {
       set_error(response.error);
-      set_code("");
-      input_refs.current[0]?.focus();
+      verifying_ref.current = false;
       set_is_loading(false);
+      input_ref.current?.focus();
+      input_ref.current?.select();
 
       return;
     }
 
     if (response.data) {
+      verifying_ref.current = false;
       set_is_loading(false);
       on_success(response.data);
 
       return;
     }
 
+    verifying_ref.current = false;
     set_is_loading(false);
-  }, [pending_login_token, on_success, trust_device, remember_me]);
-
-  handle_verify_ref.current = handle_verify;
+  };
 
   useEffect(() => {
-    if (code.length === 6) {
-      handle_verify_ref.current?.(code);
-    }
-  }, [code]);
-
-  useEffect(() => {
-    input_refs.current[0]?.focus();
+    input_ref.current?.focus();
   }, []);
 
-  const handle_code_input = (index: number, value: string) => {
-    if (!/^\d*$/.test(value)) return;
-
-    if (value.length > 1) {
-      const updated_code = (code.slice(0, index) + value).slice(0, 6);
-
-      set_code(updated_code);
-      input_refs.current[Math.min(updated_code.length, 5)]?.focus();
-
-      return;
-    }
-
-    const new_code = code.split("");
-
-    new_code[index] = value.slice(-1);
-    const updated_code = new_code.join("").slice(0, 6);
-
-    set_code(updated_code);
-
-    if (value && index < 5) {
-      input_refs.current[index + 1]?.focus();
-    }
+  const handle_change = (value: string) => {
+    set_code(value.replace(/\D/g, "").slice(0, TOTP_CODE_LENGTH));
+    if (error) set_error("");
   };
 
-  const handle_key_down = (index: number, e: React.KeyboardEvent) => {
-    if (e["key"] === "Backspace" && !code[index] && index > 0) {
-      input_refs.current[index - 1]?.focus();
-    }
-  };
-
-  const handle_paste = (e: React.ClipboardEvent) => {
-    e.preventDefault();
-    const pasted = e.clipboardData
-      .getData("text")
-      .replace(/\D/g, "")
-      .slice(0, 6);
-
-    set_code(pasted);
-    const focus_index = Math.min(pasted.length, 5);
-
-    input_refs.current[focus_index]?.focus();
+  const handle_key_down = (e: React.KeyboardEvent) => {
+    if (e["key"] === "Enter") handle_verify();
   };
 
   return (
@@ -156,43 +119,42 @@ export function TotpVerification({
       </div>
 
       <div className="space-y-4">
-        <div className="flex justify-center gap-2">
-          {[0, 1, 2, 3, 4, 5].map((index) => (
-            <Input
-              key={index}
-              ref={(el) => {
-                input_refs.current[index] = el;
-              }}
-              autoComplete={index === 0 ? "one-time-code" : "off"}
-              className="w-11 h-14 text-center text-xl font-semibold"
-              disabled={is_loading}
-              inputMode="numeric"
-              status={error ? "error" : "default"}
-              type="text"
-              value={code[index] || ""}
-              onChange={(e) => handle_code_input(index, e.target.value)}
-              onKeyDown={(e) => handle_key_down(index, e)}
-              onPaste={handle_paste}
-            />
-          ))}
-        </div>
+        <Input
+          ref={input_ref}
+          autoComplete="one-time-code"
+          className="text-center text-2xl font-semibold tracking-[0.5em]"
+          disabled={is_loading}
+          inputMode="numeric"
+          maxLength={TOTP_CODE_LENGTH}
+          placeholder="000000"
+          status={error ? "error" : "default"}
+          type="text"
+          value={code}
+          onChange={(e) => handle_change(e.target.value)}
+          onKeyDown={handle_key_down}
+        />
 
         <label className="flex items-center justify-center gap-2 text-sm text-txt-muted cursor-pointer select-none">
           <Checkbox
             checked={trust_device}
             disabled={is_loading}
-            onChange={(e) => set_trust_device(e.target.checked)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              set_trust_device(e.target.checked)
+            }
           />
           {t("auth.trust_this_device_30_days")}
         </label>
 
         {error && <p className="text-sm text-center text-red-500">{error}</p>}
 
-        {is_loading && (
-          <div className="flex justify-center">
-            <div className="w-6 h-6 border-2 rounded-full animate-spin border-edge-secondary border-t-brand" />
-          </div>
-        )}
+        <Button
+          className="w-full"
+          disabled={is_loading || code.length !== TOTP_CODE_LENGTH}
+          variant="depth"
+          onClick={handle_verify}
+        >
+          {is_loading ? t("common.verifying") : t("common.continue")}
+        </Button>
 
         <Button className="w-full" variant="outline" onClick={on_cancel}>
           {t("common.cancel")}

--- a/src/components/auth/webauthn_verification.test.tsx
+++ b/src/components/auth/webauthn_verification.test.tsx
@@ -1,0 +1,170 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+import { WebauthnVerification } from "./webauthn_verification";
+import {
+  initiate_webauthn_assertion,
+  perform_webauthn_assertion,
+} from "@/services/api/webauthn";
+
+vi.mock("@/services/api/webauthn", () => ({
+  initiate_webauthn_assertion: vi.fn(),
+  perform_webauthn_assertion: vi.fn(),
+}));
+
+vi.mock("@/lib/i18n/context", () => ({
+  use_i18n: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@aster/ui", () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: unknown;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children as never}
+    </button>
+  ),
+}));
+
+const mocked_initiate = vi.mocked(initiate_webauthn_assertion);
+const mocked_perform = vi.mocked(perform_webauthn_assertion);
+
+declare global {
+  // eslint-disable-next-line no-var
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const assertion_options = {
+  challenge: "c",
+  challenge_token: "ct",
+  rpId: "aster.cx",
+  allowCredentials: [],
+  timeout: 60000,
+  userVerification: "preferred",
+};
+
+const success_response = {
+  data: {
+    user_id: "u1",
+    username: "fate",
+    email: "fate@aster.cx",
+    csrf_token: "c",
+    encrypted_vault: "v",
+    vault_nonce: "n",
+  },
+};
+
+describe("WebauthnVerification", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  const props = () => ({
+    pending_login_token: "pending-token",
+    on_success: vi.fn(),
+    on_use_other_method: vi.fn(),
+    on_cancel: vi.fn(),
+  });
+
+  const button_by_text = (text: string) =>
+    Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes(text),
+    ) as HTMLButtonElement | undefined;
+
+  const render = async (overrides = {}) => {
+    const p = { ...props(), ...overrides };
+
+    await act(async () => {
+      root.render(<WebauthnVerification {...p} />);
+    });
+
+    return p;
+  };
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocked_initiate.mockReset();
+    mocked_perform.mockReset();
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("auto-starts the assertion exactly once on mount", async () => {
+    mocked_initiate.mockResolvedValue({ data: assertion_options });
+    mocked_perform.mockResolvedValue(success_response);
+
+    const p = await render();
+
+    expect(mocked_initiate).toHaveBeenCalledTimes(1);
+    expect(mocked_perform).toHaveBeenCalledTimes(1);
+    expect(p.on_success).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-fire the assertion on re-render", async () => {
+    mocked_initiate.mockResolvedValue({ data: assertion_options });
+    mocked_perform.mockReturnValue(new Promise(() => {}));
+
+    const p = await render();
+    await act(async () => {
+      root.render(<WebauthnVerification {...p} />);
+    });
+
+    expect(mocked_initiate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows an error with a retry that re-runs the assertion", async () => {
+    mocked_initiate.mockResolvedValue({ data: assertion_options });
+    mocked_perform.mockResolvedValueOnce({
+      data: undefined,
+      error: "authentication_cancelled",
+    });
+
+    await render();
+
+    expect(container.textContent).toContain("authentication_cancelled");
+    const retry = button_by_text("common.try_again");
+
+    expect(retry).toBeTruthy();
+
+    mocked_perform.mockResolvedValueOnce(success_response);
+    await act(async () => {
+      retry!.click();
+    });
+
+    expect(mocked_initiate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/components/auth/webauthn_verification.tsx
+++ b/src/components/auth/webauthn_verification.tsx
@@ -18,7 +18,7 @@
 // You should have received a copy of the AGPLv3
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Button } from "@aster/ui";
 
 import { use_i18n } from "@/lib/i18n/context";
@@ -46,6 +46,7 @@ export function WebauthnVerification({
   const { t } = use_i18n();
   const [is_loading, set_is_loading] = useState(false);
   const [error, set_error] = useState("");
+  const has_started = useRef(false);
 
   const start_assertion = useCallback(async () => {
     set_is_loading(true);
@@ -85,6 +86,8 @@ export function WebauthnVerification({
   }, [pending_login_token, on_success, remember_me, t]);
 
   useEffect(() => {
+    if (has_started.current) return;
+    has_started.current = true;
     start_assertion();
   }, [start_assertion]);
 

--- a/src/components/settings/totp_disable_modal.tsx
+++ b/src/components/settings/totp_disable_modal.tsx
@@ -64,63 +64,33 @@ export function TotpDisableModal({
   const [show_password, set_show_password] = useState(false);
   const [is_loading, set_is_loading] = useState(false);
   const [error, set_error] = useState("");
-  const input_refs = useRef<(HTMLInputElement | null)[]>([]);
+  const input_ref = useRef<HTMLInputElement>(null);
+  const verifying_ref = useRef(false);
 
   useEffect(() => {
     if (is_open) {
       set_code("");
       set_password("");
       set_error("");
-      setTimeout(() => input_refs.current[0]?.focus(), 100);
+      setTimeout(() => input_ref.current?.focus(), 100);
     }
   }, [is_open]);
 
-  const handle_code_input = (index: number, value: string) => {
-    if (!/^\d*$/.test(value)) return;
-
-    if (value.length > 1) {
-      const updated_code = (code.slice(0, index) + value).slice(0, 6);
-
-      set_code(updated_code);
-      input_refs.current[Math.min(updated_code.length, 5)]?.focus();
-
-      return;
-    }
-
-    const new_code = code.split("");
-
-    new_code[index] = value.slice(-1);
-    const updated_code = new_code.join("").slice(0, 6);
-
-    set_code(updated_code);
-
-    if (value && index < 5) {
-      input_refs.current[index + 1]?.focus();
-    }
-  };
-
-  const handle_key_down = (index: number, e: React.KeyboardEvent) => {
-    if (e["key"] === "Backspace" && !code[index] && index > 0) {
-      input_refs.current[index - 1]?.focus();
-    }
-  };
-
-  const handle_paste = (e: React.ClipboardEvent) => {
-    e.preventDefault();
-    const pasted = e.clipboardData
-      .getData("text")
-      .replace(/\D/g, "")
-      .slice(0, 6);
-
-    set_code(pasted);
-    const focus_index = Math.min(pasted.length, 5);
-
-    input_refs.current[focus_index]?.focus();
+  const handle_code_change = (value: string) => {
+    set_code(value.replace(/\D/g, "").slice(0, 6));
+    if (error) set_error("");
   };
 
   const handle_disable = async () => {
-    if (code.length !== 6 || !password || !user?.email) return;
+    if (
+      code.length !== 6 ||
+      !password ||
+      !user?.email ||
+      verifying_ref.current
+    )
+      return;
 
+    verifying_ref.current = true;
     set_is_loading(true);
     set_error("");
 
@@ -161,6 +131,7 @@ export function TotpDisableModal({
       set_error(t("common.failed_to_disable_2fa"));
       show_toast(t("common.failed_to_disable_2fa"), "error");
     } finally {
+      verifying_ref.current = false;
       set_is_loading(false);
     }
   };
@@ -185,27 +156,21 @@ export function TotpDisableModal({
             >
               {t("settings.authenticator_code")}
             </label>
-            <div className="flex justify-center gap-2">
-              {[0, 1, 2, 3, 4, 5].map((index) => (
-                <Input
-                  key={index}
-                  ref={(el) => {
-                    input_refs.current[index] = el;
-                  }}
-                  autoComplete={index === 0 ? "one-time-code" : "off"}
-                  className="w-11 h-14 text-center text-xl font-semibold"
-                  disabled={is_loading}
-                  id={index === 0 ? "totp-code-0" : undefined}
-                  inputMode="numeric"
-                  status={error ? "error" : "default"}
-                  type="text"
-                  value={code[index] || ""}
-                  onChange={(e) => handle_code_input(index, e.target.value)}
-                  onKeyDown={(e) => handle_key_down(index, e)}
-                  onPaste={handle_paste}
-                />
-              ))}
-            </div>
+            <Input
+              ref={input_ref}
+              autoComplete="one-time-code"
+              className="text-center text-2xl font-semibold tracking-[0.5em]"
+              disabled={is_loading}
+              id="totp-code-0"
+              inputMode="numeric"
+              maxLength={6}
+              placeholder="000000"
+              status={error ? "error" : "default"}
+              type="text"
+              value={code}
+              onChange={(e) => handle_code_change(e.target.value)}
+              onKeyDown={(e) => e["key"] === "Enter" && handle_disable()}
+            />
           </div>
 
           <div>

--- a/src/components/settings/totp_setup_modal.tsx
+++ b/src/components/settings/totp_setup_modal.tsx
@@ -69,7 +69,8 @@ export function TotpSetupModal({
   const [backup_codes, set_backup_codes] = useState<string[]>([]);
   const [is_loading, set_is_loading] = useState(false);
   const [error, set_error] = useState("");
-  const input_refs = useRef<(HTMLInputElement | null)[]>([]);
+  const input_ref = useRef<HTMLInputElement>(null);
+  const verifying_ref = useRef(false);
 
   const reset_state = useCallback(() => {
     set_step("qr_code");
@@ -88,6 +89,12 @@ export function TotpSetupModal({
       reset_state();
     }
   }, [is_open, setup_data, reset_state]);
+
+  useEffect(() => {
+    if (step === "verify") {
+      input_ref.current?.focus();
+    }
+  }, [step]);
 
   const initiate_setup = async () => {
     set_is_loading(true);
@@ -110,8 +117,10 @@ export function TotpSetupModal({
   };
 
   const handle_verify = async () => {
-    if (!setup_data || verification_code.length !== 6) return;
+    if (!setup_data || verification_code.length !== 6 || verifying_ref.current)
+      return;
 
+    verifying_ref.current = true;
     set_is_loading(true);
     set_error("");
 
@@ -122,7 +131,10 @@ export function TotpSetupModal({
 
     if (response.error) {
       set_error(response.error);
+      verifying_ref.current = false;
       set_is_loading(false);
+      input_ref.current?.focus();
+      input_ref.current?.select();
 
       return;
     }
@@ -132,53 +144,17 @@ export function TotpSetupModal({
       set_step("backup_codes");
     }
 
+    verifying_ref.current = false;
     set_is_loading(false);
   };
 
-  const handle_code_input = (index: number, value: string) => {
-    if (!/^\d*$/.test(value)) return;
-
-    if (value.length > 1) {
-      const updated_code = (verification_code.slice(0, index) + value).slice(
-        0,
-        6,
-      );
-
-      set_verification_code(updated_code);
-      input_refs.current[Math.min(updated_code.length, 5)]?.focus();
-
-      return;
-    }
-
-    const new_code = verification_code.split("");
-
-    new_code[index] = value.slice(-1);
-    const updated_code = new_code.join("").slice(0, 6);
-
-    set_verification_code(updated_code);
-
-    if (value && index < 5) {
-      input_refs.current[index + 1]?.focus();
-    }
+  const handle_code_change = (value: string) => {
+    set_verification_code(value.replace(/\D/g, "").slice(0, 6));
+    if (error) set_error("");
   };
 
-  const handle_key_down = (index: number, e: React.KeyboardEvent) => {
-    if (e["key"] === "Backspace" && !verification_code[index] && index > 0) {
-      input_refs.current[index - 1]?.focus();
-    }
-  };
-
-  const handle_paste = (e: React.ClipboardEvent) => {
-    e.preventDefault();
-    const pasted = e.clipboardData
-      .getData("text")
-      .replace(/\D/g, "")
-      .slice(0, 6);
-
-    set_verification_code(pasted);
-    const focus_index = Math.min(pasted.length, 5);
-
-    input_refs.current[focus_index]?.focus();
+  const handle_key_down = (e: React.KeyboardEvent) => {
+    if (e["key"] === "Enter") handle_verify();
   };
 
   const copy_secret = async () => {
@@ -290,25 +266,20 @@ export function TotpSetupModal({
       </ModalHeader>
       <ModalBody>
         <div className="space-y-4">
-          <div className="flex justify-center gap-2">
-            {[0, 1, 2, 3, 4, 5].map((index) => (
-              <Input
-                key={index}
-                ref={(el) => {
-                  input_refs.current[index] = el;
-                }}
-                autoComplete={index === 0 ? "one-time-code" : "off"}
-                className="w-11 h-14 text-center text-xl font-semibold"
-                inputMode="numeric"
-                status={error ? "error" : "default"}
-                type="text"
-                value={verification_code[index] || ""}
-                onChange={(e) => handle_code_input(index, e.target.value)}
-                onKeyDown={(e) => handle_key_down(index, e)}
-                onPaste={handle_paste}
-              />
-            ))}
-          </div>
+          <Input
+            ref={input_ref}
+            autoComplete="one-time-code"
+            className="text-center text-2xl font-semibold tracking-[0.5em]"
+            disabled={is_loading}
+            inputMode="numeric"
+            maxLength={6}
+            placeholder="000000"
+            status={error ? "error" : "default"}
+            type="text"
+            value={verification_code}
+            onChange={(e) => handle_code_change(e.target.value)}
+            onKeyDown={handle_key_down}
+          />
           {error && <p className="text-sm text-center text-red-500">{error}</p>}
         </div>
       </ModalBody>

--- a/src/services/api/webauthn.ts
+++ b/src/services/api/webauthn.ts
@@ -216,7 +216,14 @@ export async function perform_webauthn_registration(
     credential = (await navigator.credentials.create({
       publicKey: public_key,
     })) as PublicKeyCredential | null;
-  } catch {
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === "NotAllowedError" || err.name === "AbortError")
+    ) {
+      return { data: undefined, error: en.errors.registration_cancelled };
+    }
+
     return { data: undefined, error: en.errors.registration_failed };
   }
 
@@ -274,7 +281,14 @@ export async function perform_webauthn_assertion(
       publicKey: public_key,
       mediation: "required" as CredentialMediationRequirement,
     })) as PublicKeyCredential | null;
-  } catch {
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === "NotAllowedError" || err.name === "AbortError")
+    ) {
+      return { data: undefined, error: en.errors.authentication_cancelled };
+    }
+
     return { data: undefined, error: en.errors.authentication_failed_webauthn };
   }
 


### PR DESCRIPTION
Replaces the 6-box focus-jumping 2FA inputs with a single numeric field across all three code surfaces (login, TOTP enable, TOTP disable): inputmode=numeric, OTP autofill, manual submit, no focus-jump flicker, no auto-clear on error, focus+select on failure. Adds a synchronous double-submit guard so a fast double-Enter can't burn a code/counter. Passkey cancel/timeout now shows a clean retry instead of a hard failure, and the system prompt fires exactly once.

Scope: auth components + settings TOTP modals + webauthn (9 files, incl. component tests). vitest green (16/16), zero new tsc errors.