### PR TITLE
fix(subscriptions): confirm bulk unsubscribe once instead of per sender

### DIFF
--- a/src/components/modals/mass_unsubscribe_modal.tsx
+++ b/src/components/modals/mass_unsubscribe_modal.tsx
@@ -64,6 +64,7 @@ import {
   detect_unsubscribe_info,
   perform_unsubscribe,
 } from "@/utils/unsubscribe_detector";
+import { confirm_unsubscribe_bulk } from "@/components/modals/unsubscribe_confirmation_modal";
 
 interface Subscription {
   id: string;
@@ -314,6 +315,10 @@ export function MassUnsubscribeModal({
   const handle_unsubscribe = async () => {
     if (selected_ids.size === 0) return;
 
+    const confirmed = await confirm_unsubscribe_bulk(selected_ids.size);
+
+    if (!confirmed) return;
+
     set_is_unsubscribing(true);
     const total = selected_ids.size;
 
@@ -338,6 +343,7 @@ export function MassUnsubscribeModal({
               sub.sender_email,
               sub.sender_name,
               sub.unsub_info,
+              { skip_confirm: true },
             ),
           ),
         );

--- a/src/components/modals/unsubscribe_confirmation_modal.tsx
+++ b/src/components/modals/unsubscribe_confirmation_modal.tsx
@@ -30,12 +30,13 @@ import {
   AlertDialogDescription,
 } from "@/components/ui/alert_dialog";
 
-export type UnsubscribeConfirmKind = "url" | "mailto" | "one_click";
+export type UnsubscribeConfirmKind = "url" | "mailto" | "one_click" | "bulk";
 
 interface UnsubscribeConfirmRequest {
   kind: UnsubscribeConfirmKind;
   destination: string;
   sender_name?: string;
+  bulk_count?: number;
   resolve: (confirmed: boolean) => void;
 }
 
@@ -58,6 +59,21 @@ export function confirm_unsubscribe(
       current_request.resolve(false);
     }
     current_request = { kind, destination, sender_name, resolve };
+    notify();
+  });
+}
+
+export function confirm_unsubscribe_bulk(count: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (current_request) {
+      current_request.resolve(false);
+    }
+    current_request = {
+      kind: "bulk",
+      destination: "",
+      bulk_count: count,
+      resolve,
+    };
     notify();
   });
 }
@@ -108,8 +124,13 @@ export function UnsubscribeConfirmationModal() {
   const handle_confirm = () => close_with_animation(true);
   const handle_cancel = () => close_with_animation(false);
 
+  const is_bulk = request?.kind === "bulk";
+
   const get_display_host = () => {
     if (!request) return "";
+    if (request.kind === "bulk") {
+      return `${request.bulk_count ?? 0} ${t("common.selected")}`;
+    }
     if (request.kind === "mailto") {
       return request.destination;
     }
@@ -163,14 +184,16 @@ export function UnsubscribeConfirmationModal() {
               >
                 {get_display_host()}
               </p>
-              <p
-                className="text-[12px] break-all mt-1.5 max-h-[30vh] overflow-y-auto"
-                style={{ color: "var(--color-info)" }}
-              >
-                {request?.kind === "mailto"
-                  ? `mailto:${request.destination}`
-                  : (request?.destination ?? "")}
-              </p>
+              {!is_bulk && (
+                <p
+                  className="text-[12px] break-all mt-1.5 max-h-[30vh] overflow-y-auto"
+                  style={{ color: "var(--color-info)" }}
+                >
+                  {request?.kind === "mailto"
+                    ? `mailto:${request.destination}`
+                    : (request?.destination ?? "")}
+                </p>
+              )}
             </div>
           </div>
 

--- a/src/components/subscriptions/subscriptions_content.tsx
+++ b/src/components/subscriptions/subscriptions_content.tsx
@@ -203,8 +203,11 @@ export function SubscriptionsContent({
   const handle_bulk_unsubscribe = useCallback(async () => {
     const emails = Array.from(selected_ids);
 
-    set_selected_ids(new Set());
-    await bulk_unsubscribe(emails);
+    const did_unsubscribe = await bulk_unsubscribe(emails);
+
+    if (did_unsubscribe) {
+      set_selected_ids(new Set());
+    }
   }, [selected_ids, bulk_unsubscribe]);
 
   const handle_unsubscribe = useCallback(

--- a/src/hooks/use_subscriptions.ts
+++ b/src/hooks/use_subscriptions.ts
@@ -31,6 +31,7 @@ import {
   SUBSCRIPTION_CACHE_VERSION,
 } from "@/services/subscription_cache";
 import { perform_unsubscribe, UnsubscribeError } from "@/utils/unsubscribe_detector";
+import { confirm_unsubscribe_bulk } from "@/components/modals/unsubscribe_confirmation_modal";
 import { UNSUBSCRIBE_EVENT } from "@/hooks/use_unsubscribed_senders";
 import { use_auth } from "@/contexts/auth_context";
 import { show_toast } from "@/components/toast/simple_toast";
@@ -210,7 +211,13 @@ export function use_subscriptions() {
   );
 
   const bulk_unsubscribe = useCallback(
-    async (sender_emails: string[]) => {
+    async (sender_emails: string[]): Promise<boolean> => {
+      if (sender_emails.length === 0) return false;
+
+      const confirmed = await confirm_unsubscribe_bulk(sender_emails.length);
+
+      if (!confirmed) return false;
+
       mutating_ref.current++;
       const current_subs = cache_ref.current?.subscriptions || subscriptions;
       const batch_size = 5;
@@ -244,17 +251,22 @@ export function use_subscriptions() {
             if (!sub) return;
 
             try {
-              await perform_unsubscribe(sub.sender_email, sub.sender_name, {
-                has_unsubscribe: true,
-                method: sub.has_one_click
-                  ? "one-click"
-                  : sub.unsubscribe_link
-                    ? "link"
-                    : "none",
-                unsubscribe_link: sub.unsubscribe_link,
-                list_unsubscribe_header: sub.list_unsubscribe_header,
-                list_unsubscribe_post: sub.list_unsubscribe_post,
-              });
+              await perform_unsubscribe(
+                sub.sender_email,
+                sub.sender_name,
+                {
+                  has_unsubscribe: true,
+                  method: sub.has_one_click
+                    ? "one-click"
+                    : sub.unsubscribe_link
+                      ? "link"
+                      : "none",
+                  unsubscribe_link: sub.unsubscribe_link,
+                  list_unsubscribe_header: sub.list_unsubscribe_header,
+                  list_unsubscribe_post: sub.list_unsubscribe_post,
+                },
+                { skip_confirm: true },
+              );
             } catch {}
           }),
         );
@@ -262,6 +274,8 @@ export function use_subscriptions() {
 
       await save_subscription_cache(cache_ref.current, vault!);
       mutating_ref.current--;
+
+      return true;
     },
     [subscriptions, vault],
   );

--- a/src/utils/unsubscribe_detector.ts
+++ b/src/utils/unsubscribe_detector.ts
@@ -325,6 +325,7 @@ export async function perform_unsubscribe(
   _sender_email: string,
   sender_name: string,
   unsub_info: UnsubscribeInfo,
+  options?: { skip_confirm?: boolean },
 ): Promise<UnsubscribeResult> {
   const confirm_kind =
     unsub_info.method === "one-click"
@@ -339,14 +340,16 @@ export async function perform_unsubscribe(
     throw new UnsubscribeError("no_method");
   }
 
-  const confirmed = await confirm_unsubscribe(
-    confirm_kind,
-    confirm_destination,
-    sender_name,
-  );
+  if (!options?.skip_confirm) {
+    const confirmed = await confirm_unsubscribe(
+      confirm_kind,
+      confirm_destination,
+      sender_name,
+    );
 
-  if (!confirmed) {
-    throw new UnsubscribeError("cancelled");
+    if (!confirmed) {
+      throw new UnsubscribeError("cancelled");
+    }
   }
 
   if (unsub_info.method === "one-click" && unsub_info.unsubscribe_link) {


### PR DESCRIPTION
Closes #46

Bulk unsubscribe (subscriptions tab and the mass-unsubscribe modal) prompted a separate "Are you sure?" confirmation for every selected sender. The confirmation modal is a singleton, so the 5-at-a-time batches also resolved each other's prompts as cancelled, leaving most senders un-actioned.

Now the bulk paths confirm once for the whole selection (showing the count), then run each unsubscribe without a per-item prompt. The single-row unsubscribe is unchanged and still confirms with the destination shown.

- add optional `skip_confirm` to `perform_unsubscribe`
- add `confirm_unsubscribe_bulk(count)` to the confirmation modal (reuses existing i18n keys)
- `bulk_unsubscribe` returns whether it proceeded so the selection only clears on confirm