### PR TITLE
fix(sidebar): populate folder and tag counts on load

### DIFF
--- a/src/components/layout/sidebar/sidebar_folders.tsx
+++ b/src/components/layout/sidebar/sidebar_folders.tsx
@@ -389,7 +389,11 @@ export const SidebarFolders = memo(function SidebarFolders({
                         {folder.name}
                       </span>
                       <CountBadge
-                        count={folder_counts[folder.folder_token] ?? 0}
+                        count={
+                          folder_counts[folder.folder_token] ??
+                          folder.item_count ??
+                          0
+                        }
                         is_active={effective_selected === folder_item_id}
                       />
                       {(folder.is_locked ||

--- a/src/components/layout/sidebar/sidebar_tags.tsx
+++ b/src/components/layout/sidebar/sidebar_tags.tsx
@@ -263,7 +263,7 @@ export const SidebarTags = memo(function SidebarTags({
                         {tag.name}
                       </span>
                       <CountBadge
-                        count={tag_counts[tag.tag_token] ?? 0}
+                        count={tag_counts[tag.tag_token] ?? tag.item_count ?? 0}
                         is_active={effective_selected === tag_item_id}
                       />
                     </>

--- a/src/hooks/use_folders.ts
+++ b/src/hooks/use_folders.ts
@@ -960,12 +960,13 @@ export function use_folders(): UseFoldersReturn {
   useEffect(() => {
     if (has_passphrase_in_memory()) {
       refresh();
+      fetch_counts();
     }
 
     return () => {
       abort_ref.current?.abort();
     };
-  }, [refresh]);
+  }, [refresh, fetch_counts]);
 
   useEffect(() => {
     let counts_debounce: ReturnType<typeof setTimeout> | null = null;
@@ -995,6 +996,7 @@ export function use_folders(): UseFoldersReturn {
     const visibility_handler = () => {
       if (document.visibilityState === "visible" && has_passphrase_in_memory()) {
         fetch_folders();
+        fetch_counts();
       }
     };
 

--- a/src/hooks/use_tags.ts
+++ b/src/hooks/use_tags.ts
@@ -670,12 +670,13 @@ export function use_tags(): UseTagsReturn {
   useEffect(() => {
     if (has_passphrase_in_memory()) {
       refresh();
+      fetch_counts();
     }
 
     return () => {
       abort_ref.current?.abort();
     };
-  }, [refresh]);
+  }, [refresh, fetch_counts]);
 
   useEffect(() => {
     let counts_debounce: ReturnType<typeof setTimeout> | null = null;


### PR DESCRIPTION
Folder and tag sidebar badges were populated only by event-driven count fetches, never on mount, so they stayed blank after a cold load until an unrelated mail event happened to fire. Fetch counts on mount (and folders on refocus), and fall back to the already-loaded item_count so badges show correct numbers immediately. Preserves the existing counts-generation race guard and the use_mail_stats reconcile logic already on main.