### PR TITLE
fix(inbox): animate loading skeleton and recover stalled index builds

### DIFF
--- a/src/hooks/use_category_inbox.backstop.test.ts
+++ b/src/hooks/use_category_inbox.backstop.test.ts
@@ -1,0 +1,174 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createElement, act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+const mocks = vi.hoisted(() => ({
+  is_build_in_progress: vi.fn(() => true),
+  is_build_stalled: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/email_list_helpers", () => ({
+  fetch_mail_by_ids: vi.fn(async () => []),
+  group_emails_by_thread: (x: unknown) => x,
+  DEFAULT_PAGE_SIZE: 50,
+}));
+
+vi.mock("@/hooks/use_email_list_actions", () => ({
+  use_email_list_actions: () => ({
+    toggle_star: vi.fn(),
+    toggle_pin: vi.fn(),
+    mark_read: vi.fn(),
+    delete_email: vi.fn(),
+    archive_email: vi.fn(),
+    unarchive_email: vi.fn(),
+    mark_spam: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use_email_list_bulk", () => ({
+  use_email_list_bulk: () => ({
+    bulk_delete: vi.fn(),
+    bulk_archive: vi.fn(),
+    bulk_unarchive: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/mail_events", () => ({
+  MAIL_EVENTS: { MAIL_ITEM_UPDATED: "MAIL_ITEM_UPDATED" },
+}));
+
+vi.mock("@/components/email/hooks/preload_cache", () => ({
+  mark_preload_stale: vi.fn(),
+}));
+
+vi.mock("@/services/crypto/memory_key_store", () => ({
+  has_passphrase_in_memory: () => true,
+  on_keys_ready: () => () => {},
+}));
+
+vi.mock("@/contexts/auth_context", () => ({
+  use_auth: () => ({ has_keys: true, user: { email: "a@b.c" } }),
+}));
+
+vi.mock("@/contexts/preferences_context", () => ({
+  use_preferences: () => ({
+    preferences: {
+      date_format: "iso",
+      time_format: "24h",
+      conversation_grouping: true,
+    },
+  }),
+}));
+
+vi.mock("@/services/category_index", () => ({
+  init_category_index: vi.fn(async () => {}),
+  get_page_ids: () => [],
+  get_category_total: () => 0,
+  is_fully_built: () => false,
+  is_build_in_progress: mocks.is_build_in_progress,
+  is_build_stalled: mocks.is_build_stalled,
+  subscribe: () => () => {},
+  get_version: () => 0,
+  remove_ids: vi.fn(),
+}));
+
+import { use_category_inbox } from "@/hooks/use_category_inbox";
+
+interface SeenState {
+  is_loading: boolean;
+  has_initial_load: boolean;
+}
+
+function render_hook(): { states: SeenState[]; root: Root } {
+  const states: SeenState[] = [];
+
+  function Harness() {
+    const r = use_category_inbox("primary", 0, true);
+
+    states.push({
+      is_loading: r.state.is_loading,
+      has_initial_load: r.state.has_initial_load,
+    });
+
+    return null;
+  }
+
+  const container = document.createElement("div");
+  let root!: Root;
+
+  act(() => {
+    root = createRoot(container);
+    root.render(createElement(Harness));
+  });
+
+  return { states, root };
+}
+
+describe("use_category_inbox loading backstop", () => {
+  beforeEach(() => {
+    (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    mocks.is_build_in_progress.mockReturnValue(true);
+    mocks.is_build_stalled.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hard 30s backstop clears the skeleton even while a build claims to be in progress", () => {
+    const { states, root } = render_hook();
+
+    expect(states.at(-1)!.is_loading).toBe(true);
+
+    // Soft 10s backstop must NOT clear while a healthy build is still running.
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(states.at(-1)!.is_loading).toBe(true);
+
+    // Hard 30s backstop clears regardless - no infinite skeleton.
+    act(() => {
+      vi.advanceTimersByTime(20_000);
+    });
+    expect(states.at(-1)!.is_loading).toBe(false);
+    expect(states.at(-1)!.has_initial_load).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it("soft 10s backstop clears once the build is reported stalled", () => {
+    mocks.is_build_stalled.mockReturnValue(true);
+
+    const { states, root } = render_hook();
+
+    expect(states.at(-1)!.is_loading).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+    });
+    expect(states.at(-1)!.is_loading).toBe(false);
+
+    act(() => root.unmount());
+  });
+});

--- a/src/hooks/use_category_inbox.ts
+++ b/src/hooks/use_category_inbox.ts
@@ -53,6 +53,7 @@ import {
   get_category_total,
   is_fully_built,
   is_build_in_progress,
+  is_build_stalled,
   subscribe as subscribe_index,
   get_version as get_index_version,
   remove_ids,
@@ -167,8 +168,10 @@ export function use_category_inbox(
   useEffect(() => {
     if (!state.is_loading) return;
 
-    const safety = setTimeout(() => {
-      if (is_build_in_progress()) return;
+    // Soft backstop: clear the skeleton once the index is idle (or has wedged).
+    // A healthy build still in progress keeps the skeleton up.
+    const soft = setTimeout(() => {
+      if (is_build_in_progress() && !is_build_stalled()) return;
       set_state((prev) =>
         prev.is_loading
           ? { ...prev, is_loading: false, has_initial_load: true }
@@ -176,7 +179,21 @@ export function use_category_inbox(
       );
     }, 10_000);
 
-    return () => clearTimeout(safety);
+    // Hard backstop: never leave the user on an infinite skeleton, even if a
+    // build cannot be recovered. The index recovers on tab focus; this just
+    // guarantees the UI always resolves to content or an empty state.
+    const hard = setTimeout(() => {
+      set_state((prev) =>
+        prev.is_loading
+          ? { ...prev, is_loading: false, has_initial_load: true }
+          : prev,
+      );
+    }, 30_000);
+
+    return () => {
+      clearTimeout(soft);
+      clearTimeout(hard);
+    };
   }, [state.is_loading]);
 
   const fetch_page = useCallback(

--- a/src/services/category_index.recovery.test.ts
+++ b/src/services/category_index.recovery.test.ts
@@ -1,0 +1,273 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/services/crypto/secure_storage", () => ({
+  secure_encrypt: async (s: string) => s,
+  secure_decrypt: async (s: string) => s,
+}));
+
+vi.mock("@/services/crypto/memory_key_store", () => ({
+  has_vault_in_memory: () => true,
+  on_vault_cleared: () => {},
+}));
+
+vi.mock("@/services/account_manager", () => ({
+  get_current_account_id: async () => "acct1",
+}));
+
+const list_mail_items = vi.fn();
+
+vi.mock("@/services/api/mail", () => ({
+  list_mail_items: (...args: unknown[]) => list_mail_items(...args),
+}));
+
+vi.mock("@/services/crypto/mail_metadata", () => ({
+  decrypt_mail_metadata: async () => null,
+  update_item_metadata: async () => ({ success: true }),
+}));
+
+vi.mock("@/services/mail_categorizer", () => ({
+  classify: () => "primary",
+  category_for_tab: (c: string) => c,
+  CATEGORY_TABS: ["primary"],
+}));
+
+vi.mock("@/hooks/email_list_helpers", () => ({
+  decrypt_envelope: async () => ({ subject: "x" }),
+}));
+
+vi.mock("@/hooks/mail_events", () => ({
+  on_mail_event: () => {},
+  MAIL_EVENTS: {
+    EMAIL_RECEIVED: "EMAIL_RECEIVED",
+    MAIL_ITEMS_REMOVED: "MAIL_ITEMS_REMOVED",
+    MAIL_ACTION: "MAIL_ACTION",
+    MAIL_CHANGED: "MAIL_CHANGED",
+    MAIL_ITEM_UPDATED: "MAIL_ITEM_UPDATED",
+  },
+}));
+
+import {
+  init_category_index,
+  build_index,
+  is_build_in_progress,
+  is_build_stalled,
+  is_fully_built,
+  get_page_ids,
+  get_category_total,
+  clear_category_index,
+} from "@/services/category_index";
+
+const BASE_NOW = 1_700_000_000_000;
+
+function never_resolves() {
+  return new Promise(() => {});
+}
+
+function one_page() {
+  return {
+    data: {
+      items: [
+        {
+          id: "m1",
+          thread_token: undefined,
+          message_ts: "2026-01-01T00:00:00.000Z",
+          created_at: "2026-01-01T00:00:00.000Z",
+          is_read: false,
+          encrypted_envelope: "env",
+          envelope_nonce: "nonce",
+        },
+      ],
+      has_more: false,
+      next_cursor: null,
+    },
+  };
+}
+
+function flush(ms = 15) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Minimal correct IndexedDB for the few operations category_index performs
+// (open + onupgradeneeded, put/get/clear with tx.oncomplete). The shared test
+// setup's mock exposes objectStoreNames as a plain array with no contains().
+const idb_data = new Map<string, Map<string, unknown>>();
+
+function idb_store(name: string): Map<string, unknown> {
+  if (!idb_data.has(name)) idb_data.set(name, new Map());
+
+  return idb_data.get(name)!;
+}
+
+function install_fake_idb(): void {
+  const known = new Set<string>();
+
+  const make_db = () => ({
+    objectStoreNames: { contains: (n: string) => known.has(n) },
+    createObjectStore: (n: string) => {
+      known.add(n);
+
+      return {};
+    },
+    transaction: (store_name: string) => {
+      const tx: Record<string, unknown> = { oncomplete: null, onerror: null, error: null };
+
+      tx.objectStore = (n: string) => ({
+        put: (value: unknown, key: string) => {
+          idb_store(n).set(key, value);
+          setTimeout(() => (tx.oncomplete as (() => void) | null)?.(), 0);
+
+          return {};
+        },
+        get: (key: string) => {
+          const req: Record<string, unknown> = {
+            onsuccess: null,
+            onerror: null,
+            result: idb_store(n).get(key),
+          };
+
+          setTimeout(
+            () => (req.onsuccess as ((e: unknown) => void) | null)?.({ target: req }),
+            0,
+          );
+
+          return req;
+        },
+        clear: () => {
+          idb_store(store_name).clear();
+          setTimeout(() => (tx.oncomplete as (() => void) | null)?.(), 0);
+
+          return {};
+        },
+      });
+
+      return tx;
+    },
+    close: () => {},
+  });
+
+  const open = () => {
+    const db = make_db();
+    const req: Record<string, unknown> = {
+      onsuccess: null,
+      onerror: null,
+      onupgradeneeded: null,
+      result: db,
+    };
+
+    setTimeout(() => {
+      (req.onupgradeneeded as ((e: unknown) => void) | null)?.({ target: { result: db } });
+      (req.onsuccess as ((e: unknown) => void) | null)?.({ target: req });
+    }, 0);
+
+    return req;
+  };
+
+  (globalThis as unknown as { indexedDB: unknown }).indexedDB = {
+    open,
+    deleteDatabase: () => ({}),
+    cmp: () => 0,
+    databases: async () => [],
+  };
+}
+
+function set_visible_and_dispatch() {
+  Object.defineProperty(document, "visibilityState", {
+    value: "visible",
+    configurable: true,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("category_index build recovery", () => {
+  beforeEach(async () => {
+    install_fake_idb();
+    idb_data.clear();
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(BASE_NOW);
+    list_mail_items.mockReset();
+    await clear_category_index();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("a healthy build completes and is never reported as stalled", async () => {
+    list_mail_items.mockResolvedValue(one_page());
+
+    await init_category_index();
+    await flush();
+
+    expect(is_build_in_progress()).toBe(false);
+    expect(is_fully_built()).toBe(true);
+    expect(is_build_stalled()).toBe(false);
+    expect(get_category_total("primary")).toBe(1);
+    expect(get_page_ids("primary", 0, 50)).toEqual(["m1"]);
+  });
+
+  it("a build wedged behind a hung request is detected as stalled and recovers on tab focus", async () => {
+    // First build hangs forever (request never settles, e.g. tab frozen).
+    list_mail_items.mockReturnValue(never_resolves());
+
+    await init_category_index();
+    await flush();
+
+    expect(is_build_in_progress()).toBe(true);
+    expect(is_build_stalled()).toBe(false); // just started, making progress
+
+    // Time passes while the tab is backgrounded; the build makes no progress.
+    vi.setSystemTime(BASE_NOW + 31_000);
+    expect(is_build_stalled()).toBe(true);
+
+    // The user returns. The next attempt now succeeds.
+    list_mail_items.mockReturnValue(Promise.resolve(one_page()));
+    set_visible_and_dispatch();
+    await flush();
+
+    // The wedged latch was superseded and the index rebuilt to completion -
+    // no manual page refresh required.
+    expect(is_build_in_progress()).toBe(false);
+    expect(is_build_stalled()).toBe(false);
+    expect(is_fully_built()).toBe(true);
+    expect(get_page_ids("primary", 0, 50)).toEqual(["m1"]);
+  });
+
+  it("build_index supersedes a stalled build directly", async () => {
+    list_mail_items.mockReturnValue(never_resolves());
+
+    await init_category_index();
+    await flush();
+    expect(is_build_in_progress()).toBe(true);
+
+    vi.setSystemTime(BASE_NOW + 31_000);
+    expect(is_build_stalled()).toBe(true);
+
+    // A fresh caller (not the visibility handler) also takes over a stalled build.
+    list_mail_items.mockReturnValue(Promise.resolve(one_page()));
+    await build_index();
+    await flush();
+
+    expect(is_fully_built()).toBe(true);
+    expect(is_build_in_progress()).toBe(false);
+  });
+});

--- a/src/services/category_index.ts
+++ b/src/services/category_index.ts
@@ -52,6 +52,11 @@ const PERSIST_DEBOUNCE_MS = 1500;
 const NOTIFY_THROTTLE_MS = 350;
 const RESYNC_DEBOUNCE_MS = 4000;
 const RESYNC_MIN_INTERVAL_MS = 20000;
+// A build that makes no forward progress for this long is considered wedged
+// (e.g. an in-flight request whose abort timer was frozen while the tab was
+// backgrounded and never settled). Recovery paths may then supersede it
+// instead of deferring forever to a dead `build_in_progress` latch.
+const BUILD_STALE_MS = 30000;
 
 export interface CategoryIndexEntry {
   id: string;
@@ -83,6 +88,7 @@ let last_build_ms = 0;
 let seen_ts: Record<string, number> = {};
 let loaded_for_account: string | null = null;
 let build_in_progress = false;
+let build_progress_ms = 0;
 let build_token = 0;
 let version = 0;
 let ensure_loaded_promise: Promise<boolean> | null = null;
@@ -493,6 +499,14 @@ export function is_build_in_progress(): boolean {
   return build_in_progress;
 }
 
+// True when a build claims to be running but has made no progress for longer
+// than BUILD_STALE_MS. Used to distinguish a healthy (slow) build from one that
+// has wedged behind a dead request, so callers can recover instead of waiting
+// on a latch that will never clear without a page reload.
+export function is_build_stalled(): boolean {
+  return build_in_progress && now_ms() - build_progress_ms > BUILD_STALE_MS;
+}
+
 export function get_version(): number {
   return version;
 }
@@ -561,12 +575,19 @@ export async function build_index(options?: {
   const ok = await ensure_loaded();
 
   if (!ok) return;
-  if (build_in_progress) return;
+  if (build_in_progress) {
+    // A healthy build is left alone; a wedged one is abandoned (bump the token
+    // so its loop bails on the next checkpoint) so this call can take over.
+    if (!is_build_stalled()) return;
+    build_token += 1;
+    build_in_progress = false;
+  }
   if (fully_built && !options?.force) return;
 
   const token = build_token;
 
   build_in_progress = true;
+  build_progress_ms = now_ms();
 
   try {
     let cursor: string | undefined;
@@ -603,6 +624,7 @@ export async function build_index(options?: {
         notify_soon();
       }
 
+      build_progress_ms = now_ms();
       processed += items.length;
       cursor = next_cursor;
 
@@ -846,8 +868,24 @@ export function start_event_listeners(): void {
   });
 
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") {
-      last_build_ms = 0;
+    if (document.visibilityState !== "visible") return;
+
+    last_build_ms = 0;
+
+    // Returning to a backgrounded tab: a build that stalled while the tab was
+    // frozen may never settle on some platforms, so supersede it rather than
+    // letting the inbox sit on skeletons until a manual reload.
+    if (is_build_stalled()) {
+      build_token += 1;
+      build_in_progress = false;
+    }
+
+    if (!fully_built) {
+      // The initial reconcile never finished (interrupted or wedged). Resume it
+      // instead of only running the cheap incremental sync, which bails while a
+      // build is in progress and would leave the index permanently incomplete.
+      void build_index();
+    } else {
       schedule_resync();
     }
   });

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -275,9 +275,21 @@ button *:not(.animate-spin),
   background-color: var(--bg-hover) !important;
 }
 
+.aster_skeleton {
+  background: linear-gradient(90deg, rgba(0, 0, 0, 0.06) 25%, rgba(0, 0, 0, 0.11) 50%, rgba(0, 0, 0, 0.06) 75%);
+  background-size: 200% 100%;
+  animation: aster_skeleton_shimmer 1.4s ease-in-out infinite;
+}
+
 .dark .aster_skeleton {
   background: linear-gradient(90deg, rgba(255, 255, 255, 0.08) 25%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.08) 75%);
   background-size: 200% 100%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aster_skeleton {
+    animation: none;
+  }
 }
 
 .attachment_close_btn {
@@ -291,6 +303,11 @@ button *:not(.animate-spin),
 .thread-card-collapsed {
   background-color: var(--thread-card-bg);
   border: 1px solid var(--thread-card-border);
+}
+
+@keyframes aster_skeleton_shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 @keyframes animated-blur-1 {


### PR DESCRIPTION
Fixes the inbox loading skeleton being unreliable.

- Add the `aster_skeleton` base rule and shimmer keyframe so the loading
  placeholder animates in both light and dark, honoring reduced-motion.
  Previously only a `.dark` gradient existed (no base rule, no keyframe),
  so the shimmer never animated and was invisible in light mode.
- Detect a category index build that stops making progress and supersede
  it on tab focus, so a request frozen with a backgrounded tab no longer
  leaves the inbox waiting on a latch that never clears (the "switch tabs,
  must refresh to load" case). The visibility handler also resumes an
  unfinished initial build instead of only running the incremental sync.
- Add a hard timeout backstop so the inbox always resolves to content or
  an empty state.

Adds tests covering the stall/recovery paths and the loading backstop.
