### PR TITLE
fix(mail): password-length consistency, ratchet body render, build fix

### DIFF
--- a/src/components/compose/compose_recipients.tsx
+++ b/src/components/compose/compose_recipients.tsx
@@ -38,6 +38,7 @@ import { EmailAutocomplete } from "@/components/common/email_autocomplete";
 import { ProfileAvatar } from "@/components/ui/profile_avatar";
 import { get_email_username } from "@/lib/utils";
 import { use_i18n } from "@/lib/i18n/context";
+import { use_preferences } from "@/contexts/preferences_context";
 import {
   is_internal_email,
   discover_external_keys_batch,
@@ -252,6 +253,7 @@ export function RecipientField({
   auto_focus = false,
 }: RecipientFieldProps) {
   const { t } = use_i18n();
+  const { preferences } = use_preferences();
   const [is_expanded, set_is_expanded] = useState(false);
   const [overflow_count, set_overflow_count] = useState(0);
   const measure_ref = useRef<HTMLDivElement>(null);

--- a/src/components/email/thread_message_block.tsx
+++ b/src/components/email/thread_message_block.tsx
@@ -220,7 +220,7 @@ export function ThreadMessageBlock({
   const [show_details_modal, set_show_details_modal] = useState(false);
   const [unsub_state, set_unsub_state] = useState<"idle" | "loading" | "manual" | "done">("idle");
   const clean_body = useMemo(() => {
-    if (message.html_content) {
+    if (message.html_content && !is_ratchet_envelope(message.html_content)) {
       return message.html_content;
     }
 
@@ -253,9 +253,15 @@ export function ThreadMessageBlock({
   const is_ghost_sender = is_ghost_email(message.sender_email);
   const show_sender_name = message.display_sender_name ?? message.sender_name;
   const show_sender_email = message.display_sender_email ?? message.sender_email;
+  const has_plaintext_body =
+    !!message.body &&
+    message.body !== RATCHET_UNDECRYPTABLE_SENTINEL &&
+    !is_ratchet_envelope(message.body);
   const is_ratchet_undecryptable =
-    message.body === RATCHET_UNDECRYPTABLE_SENTINEL ||
-    is_ratchet_envelope(message.html_content);
+    !has_plaintext_body &&
+    (message.body === RATCHET_UNDECRYPTABLE_SENTINEL ||
+      is_ratchet_envelope(message.body) ||
+      is_ratchet_envelope(message.html_content));
   const rich_html_source = message.html_content || message.body;
   const is_plain_text = !rich_html_source || !has_rich_html(rich_html_source);
 

--- a/src/components/modals/delete_account_modal.tsx
+++ b/src/components/modals/delete_account_modal.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/modal";
 import { use_auth } from "@/contexts/auth_context";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { api_client } from "@/services/api/client";
 import { get_user_salt } from "@/services/api/auth";
 import { get_totp_status } from "@/services/api/totp";
@@ -184,7 +185,8 @@ export function DeleteAccountModal({
               size="lg"
               type="password"
               value={password}
-              onChange={(e) => set_password(e.target.value)}
+              maxLength={128}
+              onChange={(e) => set_password(clamp_password(e.target.value))}
             />
           </div>
 

--- a/src/components/modals/key_rotation_modal.tsx
+++ b/src/components/modals/key_rotation_modal.tsx
@@ -35,6 +35,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Input } from "@/components/ui/input";
 import { use_should_reduce_motion } from "@/provider";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 
 interface KeyRotationModalProps {
   is_open: boolean;
@@ -297,7 +298,8 @@ export function KeyRotationModal({
                         status={error ? "error" : "default"}
                         type={show_password ? "text" : "password"}
                         value={password}
-                        onChange={(e) => set_password(e.target.value)}
+                        maxLength={128}
+                        onChange={(e) => set_password(clamp_password(e.target.value))}
                         onKeyDown={handle_key_down}
                       />
                       <button

--- a/src/components/register/register_step_password.tsx
+++ b/src/components/register/register_step_password.tsx
@@ -39,6 +39,7 @@ import {
   page_transition,
 } from "@/components/register/register_types";
 import { Alert } from "@/components/register/register_shared";
+import { clamp_password } from "@/services/sanitize";
 
 interface RegisterStepPasswordProps {
   reg: UseRegistrationReturn;
@@ -91,7 +92,7 @@ export const RegisterStepPassword = ({ reg }: RegisterStepPasswordProps) => {
             type={reg.is_password_visible ? "text" : "password"}
             value={reg.password}
             onBlur={reg.handle_password_blur}
-            onChange={(e) => reg.set_password(e.target.value)}
+            onChange={(e) => reg.set_password(clamp_password(e.target.value))}
           />
           <PasswordStrengthIndicator password={reg.password} />
           {reg.password_breach_warning && (
@@ -125,7 +126,7 @@ export const RegisterStepPassword = ({ reg }: RegisterStepPasswordProps) => {
           status={reg.error ? "error" : "default"}
           type={reg.is_confirm_password_visible ? "text" : "password"}
           value={reg.confirm_password}
-          onChange={(e) => reg.set_confirm_password(e.target.value)}
+          onChange={(e) => reg.set_confirm_password(clamp_password(e.target.value))}
           onKeyDown={(e) => e["key"] === "Enter" && reg.handle_password_next()}
         />
       </div>

--- a/src/components/settings/billing/billing_dialogs.tsx
+++ b/src/components/settings/billing/billing_dialogs.tsx
@@ -28,6 +28,7 @@ import {
 } from "@heroicons/react/24/outline";
 
 import { Input } from "@/components/ui/input";
+import { clamp_password } from "@/services/sanitize";
 import {
   Modal,
   ModalHeader,
@@ -274,8 +275,9 @@ export function BillingDialogs({
                 status={cancel_password_error ? "error" : "default"}
                 type={show_cancel_password ? "text" : "password"}
                 value={cancel_password}
+                maxLength={128}
                 onChange={(e) => {
-                  set_cancel_password(e.target.value);
+                  set_cancel_password(clamp_password(e.target.value));
                   set_cancel_password_error("");
                 }}
                 onKeyDown={(e) => {

--- a/src/components/settings/delete_account_modal.tsx
+++ b/src/components/settings/delete_account_modal.tsx
@@ -44,6 +44,7 @@ import {
   base64_to_array,
 } from "@/services/crypto/key_manager";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 
 interface DeleteAccountModalProps {
   is_open: boolean;
@@ -196,7 +197,8 @@ export function DeleteAccountModal({
             placeholder={t("auth.password")}
             type={show_password ? "text" : "password"}
             value={password}
-            onChange={(e) => set_password(e.target.value)}
+            maxLength={128}
+            onChange={(e) => set_password(clamp_password(e.target.value))}
             onKeyDown={(e) =>
               e["key"] === "Enter" && is_confirmed && handle_delete()
             }

--- a/src/components/settings/encryption/key_rotation_panel.tsx
+++ b/src/components/settings/encryption/key_rotation_panel.tsx
@@ -36,6 +36,7 @@ import {
 import { Button } from "@aster/ui";
 
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { use_should_reduce_motion } from "@/provider";
@@ -248,7 +249,8 @@ export function KeyRotationPanel({
                   placeholder={t("common.enter_password_prompt")}
                   type="password"
                   value={export_password}
-                  onChange={(e) => set_export_password(e.target.value)}
+                  maxLength={128}
+                  onChange={(e) => set_export_password(clamp_password(e.target.value))}
                   onKeyDown={(e) =>
                     e["key"] === "Enter" && handle_export_secret_key()
                   }
@@ -471,7 +473,8 @@ export function KeyRotationPanel({
                   placeholder={t("common.enter_password_prompt")}
                   type="password"
                   value={regenerate_password}
-                  onChange={(e) => set_regenerate_password(e.target.value)}
+                  maxLength={128}
+                  onChange={(e) => set_regenerate_password(clamp_password(e.target.value))}
                   onKeyDown={(e) =>
                     e["key"] === "Enter" &&
                     regenerate_confirm_text.toLowerCase() === "regenerate" &&

--- a/src/components/settings/security/duress_pin_section.tsx
+++ b/src/components/settings/security/duress_pin_section.tsx
@@ -31,6 +31,7 @@ import {
   ModalFooter,
 } from "@/components/ui/modal";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { use_auth_safe } from "@/contexts/auth_context";
 import { cn } from "@/lib/utils";
 import { get_user_salt } from "@/services/api/auth";
@@ -410,8 +411,9 @@ function SetupDuressPinModal({ account_id, is_open, on_close, on_success }: {
                   autoComplete="current-password"
                   className="w-full px-3 py-2.5 pr-10 rounded-xl text-sm text-txt-primary bg-surf-secondary border border-edge-secondary focus:border-brand focus:outline-none transition-colors"
                   value={password}
+                  maxLength={128}
                   disabled={verifying_creds}
-                  onChange={(e) => set_password(e.target.value)}
+                  onChange={(e) => set_password(clamp_password(e.target.value))}
                   onKeyDown={(e) => { if (e.key === "Enter") handle_verify_credentials(); }}
                 />
                 <button type="button" tabIndex={-1}

--- a/src/components/settings/security/password_section.tsx
+++ b/src/components/settings/security/password_section.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/modal";
 import { use_should_reduce_motion } from "@/provider";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 
 interface PasswordSectionProps {
   show_password_section: boolean;
@@ -152,7 +153,8 @@ export function PasswordSection({
                   placeholder={t("settings.enter_current_password")}
                   type={show_current_password ? "text" : "password"}
                   value={current_password}
-                  onChange={(e) => set_current_password(e.target.value)}
+                  maxLength={128}
+                  onChange={(e) => set_current_password(clamp_password(e.target.value))}
                 />
                 <button
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-txt-muted"
@@ -185,8 +187,9 @@ export function PasswordSection({
                   placeholder={t("settings.enter_new_password")}
                   type={show_new_password ? "text" : "password"}
                   value={new_password}
+                  maxLength={128}
                   onBlur={on_new_password_blur}
-                  onChange={(e) => set_new_password(e.target.value)}
+                  onChange={(e) => set_new_password(clamp_password(e.target.value))}
                 />
                 <button
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-txt-muted"
@@ -223,7 +226,8 @@ export function PasswordSection({
                 placeholder={t("settings.confirm_new_password_placeholder")}
                 type="password"
                 value={confirm_password}
-                onChange={(e) => set_confirm_password(e.target.value)}
+                maxLength={128}
+                onChange={(e) => set_confirm_password(clamp_password(e.target.value))}
               />
             </div>
 

--- a/src/components/settings/security/vanguard_section.tsx
+++ b/src/components/settings/security/vanguard_section.tsx
@@ -33,6 +33,7 @@ import {
   ModalFooter,
 } from "@/components/ui/modal";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { use_plan_limits } from "@/hooks/use_plan_limits";
 import { use_auth_safe } from "@/contexts/auth_context";
 import { AppLockSection } from "@/components/settings/security/app_lock_section";
@@ -176,7 +177,8 @@ function LockdownSection({ account_id }: { account_id: string }) {
               type="password"
               placeholder={t("settings.current_password")}
               value={password}
-              onChange={(e) => set_password(e.target.value)}
+              maxLength={128}
+              onChange={(e) => set_password(clamp_password(e.target.value))}
               autoComplete="current-password"
               disabled={disabling}
             />

--- a/src/components/settings/totp_disable_modal.tsx
+++ b/src/components/settings/totp_disable_modal.tsx
@@ -40,6 +40,7 @@ import { disable_totp } from "@/services/api/totp";
 import { get_user_salt } from "@/services/api/auth";
 import { use_auth } from "@/contexts/auth_context";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import {
   hash_email,
   derive_password_hash,
@@ -189,7 +190,8 @@ export function TotpDisableModal({
                 status={error ? "error" : "default"}
                 type={show_password ? "text" : "password"}
                 value={password}
-                onChange={(e) => set_password(e.target.value)}
+                maxLength={128}
+                onChange={(e) => set_password(clamp_password(e.target.value))}
               />
               <button
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-txt-muted"

--- a/src/hooks/email_list_helpers.ratchet_preview.test.ts
+++ b/src/hooks/email_list_helpers.ratchet_preview.test.ts
@@ -1,0 +1,96 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect } from "vitest";
+
+import type { DecryptedEnvelope } from "@/types/email";
+import type { MailItem } from "@/services/api/mail";
+
+import { mail_to_email } from "./email_list_helpers";
+import { RATCHET_UNDECRYPTABLE_SENTINEL } from "@/utils/email_crypto";
+
+const RAW_RATCHET_ENVELOPE = JSON.stringify({
+  type: "double_ratchet_v2",
+  sender_identity_key: "AAAA",
+  recipients: { "me@astermail.org": { header: {}, ciphertext: "BBBB" } },
+});
+
+function make_item(): MailItem {
+  return {
+    id: "msg-1",
+    created_at: "2026-06-19T00:00:00.000Z",
+    is_external: false,
+  } as unknown as MailItem;
+}
+
+function make_envelope(
+  body_text: string,
+  body_html: string,
+): DecryptedEnvelope {
+  return {
+    from: { name: "Superhuman", email: "support@aster.cx" },
+    to: [{ name: "", email: "me@astermail.org" }],
+    cc: [],
+    bcc: [],
+    subject: "Password Issues when making changes",
+    body_text,
+    body_html,
+  } as unknown as DecryptedEnvelope;
+}
+
+const FORMAT = { now: new Date("2026-06-19T01:00:00.000Z") } as never;
+
+describe("mail_to_email ratchet preview", () => {
+  it("shows the decrypted text, not the undecryptable sentinel, when body_html is still a raw ratchet envelope", () => {
+    // Internal ratchet mail stores the SAME envelope in body_text and
+    // body_html. The list path decrypts only body_text; body_html stays raw.
+    const email = mail_to_email(
+      make_item(),
+      make_envelope("Hello, I am not sure whats going on", RAW_RATCHET_ENVELOPE),
+      null,
+      FORMAT,
+    );
+
+    expect(email.preview).not.toBe(RATCHET_UNDECRYPTABLE_SENTINEL);
+    expect(email.preview).toContain("Hello, I am not sure");
+  });
+
+  it("still shows the sentinel when the decrypted text itself failed", () => {
+    const email = mail_to_email(
+      make_item(),
+      make_envelope(RATCHET_UNDECRYPTABLE_SENTINEL, RAW_RATCHET_ENVELOPE),
+      null,
+      FORMAT,
+    );
+
+    expect(email.preview).toBe(RATCHET_UNDECRYPTABLE_SENTINEL);
+  });
+
+  it("shows the sentinel when there is no decrypted text and only a raw ratchet html body", () => {
+    const email = mail_to_email(
+      make_item(),
+      make_envelope("", RAW_RATCHET_ENVELOPE),
+      null,
+      FORMAT,
+    );
+
+    expect(email.preview).toBe(RATCHET_UNDECRYPTABLE_SENTINEL);
+  });
+});

--- a/src/hooks/email_list_helpers.ts
+++ b/src/hooks/email_list_helpers.ts
@@ -346,12 +346,13 @@ export function mail_to_email(
   const recipient_addresses = envelope.to?.map((r) => r.email).filter(Boolean);
 
   const resolved_text = envelope.body_text ?? envelope.text_body ?? "";
-  const resolved_html = envelope.body_html ?? envelope.html_body ?? "";
+  const raw_html = envelope.body_html ?? envelope.html_body ?? "";
+  const resolved_html = is_ratchet_envelope(raw_html) ? "" : raw_html;
   const is_undecryptable_body =
     resolved_text === RATCHET_UNDECRYPTABLE_SENTINEL ||
     resolved_html === RATCHET_UNDECRYPTABLE_SENTINEL ||
     is_ratchet_envelope(resolved_text) ||
-    is_ratchet_envelope(resolved_html);
+    (!resolved_text && is_ratchet_envelope(raw_html));
   const preview_text = is_undecryptable_body
     ? RATCHET_UNDECRYPTABLE_SENTINEL
     : strip_html_tags(resolved_text || resolved_html).substring(0, 100);
@@ -444,6 +445,7 @@ export async function fetch_mail_by_ids(
           envelope.body_text,
           user_email,
           envelope.from?.email || "",
+          item.id,
         );
 
         envelope.body_text = bundle.body;
@@ -617,6 +619,7 @@ export async function fetch_mail_from_api(
           envelope.body_text,
           user_email,
           envelope.from?.email || "",
+          item.id,
         );
 
         envelope.body_text = bundle.body;

--- a/src/pages/forgot_password.tsx
+++ b/src/pages/forgot_password.tsx
@@ -58,6 +58,7 @@ import {
   sanitize_username,
   validate_password_strength,
   timing_safe_delay,
+  clamp_password,
 } from "@/services/sanitize";
 import {
   EyeIcon,
@@ -755,7 +756,7 @@ export default function ForgotPasswordPage() {
                   status={error ? "error" : "default"}
                   type={is_password_visible ? "text" : "password"}
                   value={password}
-                  onChange={(e) => set_password(e.target.value)}
+                  onChange={(e) => set_password(clamp_password(e.target.value))}
                 />
                 <PasswordStrengthIndicator password={password} />
               </div>
@@ -776,7 +777,7 @@ export default function ForgotPasswordPage() {
                 status={error ? "error" : "default"}
                 type={is_confirm_visible ? "text" : "password"}
                 value={confirm_password}
-                onChange={(e) => set_confirm_password(e.target.value)}
+                onChange={(e) => set_confirm_password(clamp_password(e.target.value))}
                 onKeyDown={(e) =>
                   e["key"] === "Enter" && handle_password_submit()
                 }

--- a/src/pages/mobile/forgot_password/password_step.tsx
+++ b/src/pages/mobile/forgot_password/password_step.tsx
@@ -24,6 +24,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeftIcon } from "@heroicons/react/20/solid";
 
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { Input } from "@/components/ui/input";
 import { EyeIcon, EyeSlashIcon } from "@/components/auth/auth_styles";
 import { PasswordStrengthIndicator } from "@/components/register/password_strength";
@@ -124,7 +125,7 @@ export function PasswordStep({
                 status={error ? "error" : "default"}
                 type={is_password_visible ? "text" : "password"}
                 value={password}
-                onChange={(e) => set_password(e.target.value)}
+                onChange={(e) => set_password(clamp_password(e.target.value))}
               />
               <button
                 className="flex min-h-[44px] min-w-[44px] items-center justify-center focus:outline-none"
@@ -148,7 +149,7 @@ export function PasswordStep({
                 status={error ? "error" : "default"}
                 type={is_confirm_visible ? "text" : "password"}
                 value={confirm_password}
-                onChange={(e) => set_confirm_password(e.target.value)}
+                onChange={(e) => set_confirm_password(clamp_password(e.target.value))}
                 onKeyDown={(e) => e["key"] === "Enter" && on_submit()}
               />
               <button

--- a/src/pages/mobile/mobile_register/step_password.tsx
+++ b/src/pages/mobile/mobile_register/step_password.tsx
@@ -24,6 +24,7 @@ import { motion, AnimatePresence } from "framer-motion";
 
 import { use_registration } from "@/components/register/hooks/use_registration";
 import { Input } from "@/components/ui/input";
+import { clamp_password } from "@/services/sanitize";
 import {
   EyeIcon,
   EyeSlashIcon,
@@ -111,7 +112,7 @@ export function StepPassword({
                 type={reg.is_password_visible ? "text" : "password"}
                 value={reg.password}
                 onChange={(e) => {
-                  reg.set_password(e.target.value);
+                  reg.set_password(clamp_password(e.target.value));
                   reg.set_error("");
                 }}
               />
@@ -149,7 +150,7 @@ export function StepPassword({
                 type={reg.is_confirm_password_visible ? "text" : "password"}
                 value={reg.confirm_password}
                 onChange={(e) => {
-                  reg.set_confirm_password(e.target.value);
+                  reg.set_confirm_password(clamp_password(e.target.value));
                   reg.set_error("");
                 }}
                 onKeyDown={(e) =>

--- a/src/pages/mobile/mobile_sign_in.tsx
+++ b/src/pages/mobile/mobile_sign_in.tsx
@@ -36,7 +36,11 @@ import {
 } from "@/services/crypto/key_manager";
 import { login_user, get_user_salt, get_user_info } from "@/services/api/auth";
 import { check_and_replenish_prekeys } from "@/services/crypto/prekey_service";
-import { sanitize_username, timing_safe_delay } from "@/services/sanitize";
+import {
+  sanitize_username,
+  timing_safe_delay,
+  clamp_password,
+} from "@/services/sanitize";
 import {
   EyeIcon,
   EyeSlashIcon,
@@ -315,12 +319,6 @@ export default function MobileSignInPage() {
       return;
     }
 
-    if (password.length > 128) {
-      await timing_safe_delay();
-      set_error(t("errors.password_too_long"));
-
-      return;
-    }
 
     const email = `${clean_username}@${final_domain}`;
 
@@ -854,7 +852,7 @@ export default function MobileSignInPage() {
                   status={error ? "error" : "default"}
                   type={is_password_visible ? "text" : "password"}
                   value={password}
-                  onChange={(e) => set_password(e.target.value)}
+                  onChange={(e) => set_password(clamp_password(e.target.value))}
                   onKeyDown={(e) =>
                     e["key"] === "Enter" && !is_loading && handle_login()
                   }

--- a/src/pages/mobile/mobile_thread_message.tsx
+++ b/src/pages/mobile/mobile_thread_message.tsx
@@ -42,7 +42,10 @@ import { get_image_proxy_url } from "@/lib/image_proxy";
 import { MobileAttachmentRow } from "@/components/mobile/mobile_attachment_row";
 import { ProfileAvatar } from "@/components/ui/profile_avatar";
 import { use_preferences } from "@/contexts/preferences_context";
-import { RATCHET_UNDECRYPTABLE_SENTINEL } from "@/utils/email_crypto";
+import {
+  RATCHET_UNDECRYPTABLE_SENTINEL,
+  is_ratchet_envelope,
+} from "@/utils/email_crypto";
 import { is_lockdown_enabled, LOCKDOWN_CHANGED_EVENT } from "@/services/lockdown_store";
 import { use_auth_safe } from "@/contexts/auth_context";
 
@@ -112,15 +115,22 @@ export function MobileThreadMessage({
   }, [auth?.current_account_id]);
 
   const clean_body = useMemo(() => {
-    if (message.html_content) {
+    if (message.html_content && !is_ratchet_envelope(message.html_content)) {
       return message.html_content;
     }
 
     return strip_quotes(message.body);
   }, [message.body, message.html_content]);
 
+  const has_plaintext_body =
+    !!message.body &&
+    message.body !== RATCHET_UNDECRYPTABLE_SENTINEL &&
+    !is_ratchet_envelope(message.body);
   const is_ratchet_undecryptable =
-    message.body === RATCHET_UNDECRYPTABLE_SENTINEL;
+    !has_plaintext_body &&
+    (message.body === RATCHET_UNDECRYPTABLE_SENTINEL ||
+      is_ratchet_envelope(message.body) ||
+      is_ratchet_envelope(message.html_content));
 
   const collapsed_preview = useMemo(() => {
     if (clean_body === RATCHET_UNDECRYPTABLE_SENTINEL) {

--- a/src/pages/mobile/settings/billing_section.tsx
+++ b/src/pages/mobile/settings/billing_section.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/settings/billing/billing_constants";
 
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { use_mail_stats } from "@/hooks/use_mail_stats";
 import { Spinner } from "@/components/ui/spinner";
 import { Input } from "@/components/ui/input";
@@ -1273,8 +1274,9 @@ export function BillingSection({
                 status={cancel_password_error ? "error" : "default"}
                 type={show_cancel_password ? "text" : "password"}
                 value={cancel_password}
+                maxLength={128}
                 onChange={(e) => {
-                  set_cancel_password(e.target.value);
+                  set_cancel_password(clamp_password(e.target.value));
                   set_cancel_password_error("");
                 }}
                 onKeyDown={(e) => {

--- a/src/pages/mobile/settings/encryption_section.tsx
+++ b/src/pages/mobile/settings/encryption_section.tsx
@@ -41,6 +41,7 @@ import {
 } from "./shared";
 
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { Spinner } from "@/components/ui/spinner";
 import { Input } from "@/components/ui/input";
 import { ConfirmationModal } from "@/components/modals/confirmation_modal";
@@ -172,7 +173,8 @@ export function EncryptionSection({
               status={auth_error ? "error" : "default"}
               type="password"
               value={password}
-              onChange={(e) => set_password(e.target.value)}
+              maxLength={128}
+              onChange={(e) => set_password(clamp_password(e.target.value))}
               onKeyDown={(e) =>
                 e.key === "Enter" && !totp_required && handle_authenticate()
               }
@@ -755,7 +757,8 @@ export function EncryptionSection({
                 status={enc.export_error ? "error" : "default"}
                 type="password"
                 value={enc.export_password}
-                onChange={(e) => enc.set_export_password(e.target.value)}
+                maxLength={128}
+                onChange={(e) => enc.set_export_password(clamp_password(e.target.value))}
                 onKeyDown={(e) =>
                   e.key === "Enter" && enc.handle_export_secret_key()
                 }
@@ -863,7 +866,8 @@ export function EncryptionSection({
                 status={enc.regenerate_error ? "error" : "default"}
                 type="password"
                 value={enc.regenerate_password}
-                onChange={(e) => enc.set_regenerate_password(e.target.value)}
+                maxLength={128}
+                onChange={(e) => enc.set_regenerate_password(clamp_password(e.target.value))}
                 onKeyDown={(e) =>
                   e.key === "Enter" &&
                   enc.regenerate_confirm_text.toLowerCase() === "regenerate" &&

--- a/src/pages/mobile/settings/security_section.tsx
+++ b/src/pages/mobile/settings/security_section.tsx
@@ -42,6 +42,7 @@ import {
 import { use_auth } from "@/contexts/auth_context";
 import { use_preferences } from "@/contexts/preferences_context";
 import { use_i18n } from "@/lib/i18n/context";
+import { clamp_password } from "@/services/sanitize";
 import { Spinner } from "@/components/ui/spinner";
 import { Input } from "@/components/ui/input";
 import { api_client } from "@/services/api/client";
@@ -576,7 +577,8 @@ export function SecuritySection({
                   status={pw_error ? "error" : "default"}
                   type={show_current_pw ? "text" : "password"}
                   value={current_password}
-                  onChange={(e) => set_current_password(e.target.value)}
+                  maxLength={128}
+                  onChange={(e) => set_current_password(clamp_password(e.target.value))}
                 />
                 <button
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)]"
@@ -604,8 +606,9 @@ export function SecuritySection({
                       set_pw_breach_warning(result.is_breached);
                     }
                   }}
+                  maxLength={128}
                   onChange={(e) => {
-                    set_new_password(e.target.value);
+                    set_new_password(clamp_password(e.target.value));
                     set_pw_breach_warning(false);
                   }}
                 />
@@ -635,7 +638,8 @@ export function SecuritySection({
                 status={pw_error ? "error" : "default"}
                 type="password"
                 value={confirm_password}
-                onChange={(e) => set_confirm_password(e.target.value)}
+                maxLength={128}
+                onChange={(e) => set_confirm_password(clamp_password(e.target.value))}
               />
               {pw_error && (
                 <p className="text-[13px] text-[var(--color-danger,#ef4444)]">

--- a/src/pages/reset_password.tsx
+++ b/src/pages/reset_password.tsx
@@ -49,6 +49,7 @@ import {
 import {
   validate_password_strength,
   timing_safe_delay,
+  clamp_password,
 } from "@/services/sanitize";
 import {
   EyeIcon,
@@ -427,7 +428,7 @@ export default function ResetPasswordPage() {
                   status={error ? "error" : "default"}
                   type={is_password_visible ? "text" : "password"}
                   value={password}
-                  onChange={(e) => set_password(e.target.value)}
+                  onChange={(e) => set_password(clamp_password(e.target.value))}
                 />
                 <PasswordStrengthIndicator password={password} />
               </div>
@@ -448,7 +449,7 @@ export default function ResetPasswordPage() {
                 status={error ? "error" : "default"}
                 type={is_confirm_visible ? "text" : "password"}
                 value={confirm_password}
-                onChange={(e) => set_confirm_password(e.target.value)}
+                onChange={(e) => set_confirm_password(clamp_password(e.target.value))}
                 onKeyDown={(e) => e["key"] === "Enter" && handle_submit()}
               />
             </div>

--- a/src/pages/sign_in.tsx
+++ b/src/pages/sign_in.tsx
@@ -38,7 +38,11 @@ import {
 import { login_user, get_user_salt, get_user_info } from "@/services/api/auth";
 import { resend_pending_verification } from "@/services/api/recovery_email";
 import { check_and_replenish_prekeys } from "@/services/crypto/prekey_service";
-import { sanitize_username, timing_safe_delay } from "@/services/sanitize";
+import {
+  sanitize_username,
+  timing_safe_delay,
+  clamp_password,
+} from "@/services/sanitize";
 import { EyeIcon, EyeSlashIcon } from "@/components/auth/auth_styles";
 import {
   TurnstileWidget,
@@ -816,13 +820,6 @@ export default function SignInPage() {
       return;
     }
 
-    if (password.length > 128) {
-      await timing_safe_delay();
-      set_error(t("errors.password_too_long"));
-
-      return;
-    }
-
     const email = `${clean_username}@${final_domain}`;
 
     if (is_adding_account) {
@@ -1317,7 +1314,7 @@ export default function SignInPage() {
                     status={error ? "error" : "default"}
                     type={is_password_visible ? "text" : "password"}
                     value={password}
-                    onChange={(e) => set_password(e.target.value)}
+                    onChange={(e) => set_password(clamp_password(e.target.value))}
                     onKeyDown={(e) =>
                       e["key"] === "Enter" && !is_loading && handle_login()
                     }

--- a/src/services/crypto/key_manager_pgp.ts
+++ b/src/services/crypto/key_manager_pgp.ts
@@ -20,6 +20,8 @@
 //
 import * as openpgp from "openpgp";
 
+import { clamp_password } from "@/services/sanitize";
+
 const VAULT_SCHEME_VERSION = 1;
 const VAULT_AAD_PREFIX = "aster-vault-v";
 const VAULT_AAD_WRITE_ENABLED = false;
@@ -148,7 +150,7 @@ export async function derive_password_hash(
   salt: Uint8Array,
 ): Promise<{ hash: string; salt: string }> {
   const encoder = new TextEncoder();
-  const password_data = encoder.encode(password);
+  const password_data = encoder.encode(clamp_password(password));
 
   const key_material = await crypto.subtle.importKey(
     "raw",

--- a/src/services/password_length_contract.test.ts
+++ b/src/services/password_length_contract.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect } from "vitest";
+
+import { clamp_password, MAX_PASSWORD_LENGTH } from "@/services/sanitize";
+import { derive_password_hash } from "@/services/crypto/key_manager_pgp";
+
+describe("clamp_password", () => {
+  it("leaves a password within the limit untouched", () => {
+    const pw = "Correct-Horse-Battery-Staple-1";
+
+    expect(clamp_password(pw)).toBe(pw);
+  });
+
+  it("leaves a password at exactly the limit untouched", () => {
+    const pw = "a".repeat(MAX_PASSWORD_LENGTH);
+
+    expect(clamp_password(pw)).toHaveLength(MAX_PASSWORD_LENGTH);
+    expect(clamp_password(pw)).toBe(pw);
+  });
+
+  it("truncates an over-length password to the limit", () => {
+    const pw = "a".repeat(MAX_PASSWORD_LENGTH + 50);
+
+    expect(clamp_password(pw)).toHaveLength(MAX_PASSWORD_LENGTH);
+    expect(clamp_password(pw)).toBe("a".repeat(MAX_PASSWORD_LENGTH));
+  });
+
+  it("is idempotent", () => {
+    const pw = "z".repeat(MAX_PASSWORD_LENGTH + 200);
+
+    expect(clamp_password(clamp_password(pw))).toBe(clamp_password(pw));
+  });
+});
+
+describe("derive_password_hash length contract", () => {
+  const salt = new Uint8Array(16).fill(7);
+
+  it("produces an identical hash regardless of where the same password is entered", async () => {
+    const pw = "Some-User-Password-123";
+
+    const login = await derive_password_hash(pw, salt);
+    const reauth = await derive_password_hash(pw, salt);
+
+    expect(reauth.hash).toBe(login.hash);
+  });
+
+  it("hashes an over-length password identically to its clamped form", async () => {
+    const long_pw = "p".repeat(MAX_PASSWORD_LENGTH + 64);
+
+    const from_raw = await derive_password_hash(long_pw, salt);
+    const from_clamped = await derive_password_hash(
+      clamp_password(long_pw),
+      salt,
+    );
+
+    expect(from_raw.hash).toBe(from_clamped.hash);
+  });
+
+  it("does not change the hash of a normal in-limit password", async () => {
+    const pw = "n".repeat(MAX_PASSWORD_LENGTH - 1);
+
+    const a = await derive_password_hash(pw, salt);
+    const b = await derive_password_hash(clamp_password(pw), salt);
+
+    expect(a.hash).toBe(b.hash);
+  });
+});

--- a/src/services/sanitize.ts
+++ b/src/services/sanitize.ts
@@ -18,6 +18,14 @@
 // You should have received a copy of the AGPLv3
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
+export const MAX_PASSWORD_LENGTH = 128;
+
+export function clamp_password(password: string): string {
+  if (password.length <= MAX_PASSWORD_LENGTH) return password;
+
+  return password.slice(0, MAX_PASSWORD_LENGTH);
+}
+
 export function sanitize_username(input: string): string {
   return input
     .toLowerCase()

--- a/src/utils/email_crypto.ts
+++ b/src/utils/email_crypto.ts
@@ -351,6 +351,7 @@ export async function decrypt_body_text(
   body_text: string,
   user_email: string,
   sender_email: string,
+  message_id?: string,
 ): Promise<string> {
   if (!body_text) return body_text;
 
@@ -358,6 +359,7 @@ export async function decrypt_body_text(
     body_text,
     user_email,
     sender_email,
+    message_id,
   );
 
   result = await try_decrypt_pgp_body(result);
@@ -375,8 +377,14 @@ export async function decrypt_body_text_with_bundle(
   body_text: string,
   user_email: string,
   sender_email: string,
+  message_id?: string,
 ): Promise<SubjectBundle> {
-  const decrypted = await decrypt_body_text(body_text, user_email, sender_email);
+  const decrypted = await decrypt_body_text(
+    body_text,
+    user_email,
+    sender_email,
+    message_id,
+  );
   return extract_subject_bundle(decrypted);
 }
 


### PR DESCRIPTION
Clean extraction onto main (zero conflicts):
- Consistent 128-char password contract across login and all re-auth flows (fixes password-manager autofill mismatch on downgrade/delete/change-password/key-rotation/recovery).
- Render decrypted ratchet body in list and thread views (no false 'could not be decrypted').
- Thread message_id through ratchet body decryption.
- Restore use_preferences() in compose_recipients (fixes pre-existing main tsc break).

Backend counterpart already on main (free-tier plan-limit fallback, import/sent-copy failure surfacing). All deployed and verified.