### PR TITLE
fix(import): open provider oauth in system browser on desktop

### DIFF
--- a/src/components/settings/connect_provider_modal.tsx
+++ b/src/components/settings/connect_provider_modal.tsx
@@ -146,10 +146,22 @@ export function ConnectProviderModal({
         return;
       }
 
-      // Tauri uses a different origin (tauri://localhost) so postMessage from the popup
-      // would be cross-origin and silently dropped. Use full-page redirect instead.
       if (is_tauri()) {
-        window.location.replace(parsed.toString());
+        try {
+          const core = await import("@tauri-apps/api/core");
+          await core.invoke("open_external_url", { url: parsed.toString() });
+        } catch {
+          show_toast(
+            t("settings.oauth_import_error", {
+              reason: t("settings.oauth_reason_unknown"),
+            }),
+            "error",
+          );
+          set_is_loading(false);
+          return;
+        }
+        on_oauth_success?.(provider);
+        on_close();
         return;
       }
 

--- a/src/components/settings/import_section.tsx
+++ b/src/components/settings/import_section.tsx
@@ -1235,7 +1235,7 @@ export function ImportSection() {
         if (found) { stopped = true; window.clearInterval(id); }
       }, 2000);
 
-      window.setTimeout(() => window.clearInterval(id), 60000);
+      window.setTimeout(() => window.clearInterval(id), 300000);
     });
   }, [connected_accounts, setup_oauth_folders]);
 


### PR DESCRIPTION
Desktop (Tauri) builds handled provider OAuth connect with a full-page `window.location.replace` to the authorize URL, which navigated the app webview to a remote origin. That destroyed the in-memory session (dumping the user into the device pairing gate) and killed the Tauri IPC bridge (so "Get new code" did nothing).

Now the desktop path opens the authorize URL in the system browser via the existing `open_external_url` command and reuses the existing post-OAuth polling. The backend `oauth_callback` derives the user from the stored `oauth_states` row, so completing OAuth in any browser links to the correct account. Also extends the post-OAuth poll window from 60s to 300s for the slower system-browser login.

Web popup flow is unchanged.