### PR TITLE
chore(quality): clear codeql maintainability and reliability findings

### DIFF
--- a/scripts/validate_translations.mjs
+++ b/scripts/validate_translations.mjs
@@ -6,7 +6,6 @@ for (const code of codes) {
   const txt = fs.readFileSync(`src/lib/i18n/translations/${code}.ts`, "utf8");
   let depth = 0, inStr = null, inTpl = false, esc = false, started = false;
   let lineNo = 1, colNo = 0;
-  let bracketStart = -1;
   for (let i = 0; i < txt.length; i++) {
     const c = txt[i];
     if (c === "\n") { lineNo++; colNo = 0; } else { colNo++; }
@@ -23,7 +22,7 @@ for (const code of codes) {
     }
     if (c === '"' || c === "'") { inStr = c; continue; }
     if (c === "`") { inTpl = true; continue; }
-    if (c === "{") { if (!started) { bracketStart = i; started = true; } depth++; }
+    if (c === "{") { if (!started) { started = true; } depth++; }
     else if (c === "}") { depth--; if (depth === 0 && started) { break; } }
   }
   const status = depth === 0 && !inStr && !inTpl ? "OK" : `FAIL depth=${depth} inStr=${inStr} inTpl=${inTpl}`;

--- a/src/components/compose/compose_modal.tsx
+++ b/src/components/compose/compose_modal.tsx
@@ -273,7 +273,7 @@ export function ComposeModal({
 
                   <div className="px-4 pb-1 min-h-0 overflow-y-auto">
                     <ComposeFormFields
-                      auto_focus_to={is_open && !edit_draft}
+                      auto_focus_to={!edit_draft}
                       compose={compose}
                     />
                   </div>

--- a/src/components/email/email_context_menu.tsx
+++ b/src/components/email/email_context_menu.tsx
@@ -449,7 +449,8 @@ function EmailContextMenuContentInner({
         !is_scheduled &&
         (is_trash ||
           is_spam ||
-          (!is_trash && !is_spam && (on_archive || on_spam)) ||
+          on_archive ||
+          on_spam ||
           on_delete) && <ContextMenuSeparator />}
 
       {is_trash && on_restore && (

--- a/src/components/email/email_detail/email_detail_body.tsx
+++ b/src/components/email/email_detail/email_detail_body.tsx
@@ -464,13 +464,7 @@ export function EmailDetailBody({
               {t("common.unable_to_decrypt" as TranslationKey)}
             </h3>
             <p className="text-xs sm:text-sm text-txt-muted">
-              {error && /corrupt|malformed|ciphertext/i.test(error)
-                ? t("errors.decrypt_corrupt_ciphertext")
-                : error && /sender|envelope/i.test(error)
-                  ? t("errors.decrypt_sender_error")
-                  : error && /key|wrong/i.test(error)
-                    ? t("errors.decrypt_wrong_key")
-                    : t("common.decrypt_session_expired_message" as TranslationKey)}
+              {t("common.decrypt_session_expired_message" as TranslationKey)}
             </p>
           </div>
           <div className="p-3 rounded-lg max-w-sm w-full bg-amber-500/[0.08] border border-amber-500/20">

--- a/src/components/email/hooks/use_email_detail.ts
+++ b/src/components/email/hooks/use_email_detail.ts
@@ -739,7 +739,6 @@ export function use_email_detail() {
           preferences.conversation_grouping !== false &&
           stored_grouped_email_ids &&
           stored_grouped_email_ids.length > 1 &&
-          email_id &&
           stored_grouped_email_ids.includes(email_id)
         ) {
           const group_messages = await fetch_and_decrypt_virtual_group(

--- a/src/components/email/hooks/use_popup_viewer.ts
+++ b/src/components/email/hooks/use_popup_viewer.ts
@@ -465,7 +465,6 @@ export function use_popup_viewer({
           preferences.conversation_grouping !== false &&
           grouped_email_ids &&
           grouped_email_ids.length > 1 &&
-          email_id &&
           grouped_email_ids.includes(email_id)
         ) {
           const group_messages = await fetch_and_decrypt_virtual_group(

--- a/src/components/modals/hooks/use_reply_modal.ts
+++ b/src/components/modals/hooks/use_reply_modal.ts
@@ -311,7 +311,7 @@ export function use_reply_modal({
 
   useEffect(() => {
     return subscribe_preferred_sender((id) => set_preferred_sender_state(id));
-  }, [])
+  }, []);
 
   const handle_set_preferred = useCallback(
     (id: string | null) => {

--- a/src/components/settings/billing/family_section.tsx
+++ b/src/components/settings/billing/family_section.tsx
@@ -2523,7 +2523,7 @@ export function FamilySection({ is_family_plan }: FamilySectionProps) {
       {tab === "retention" && is_owner && <RetentionContent other_member_count={active_members.length - 1} initial_retention={preloaded_retention} />}
 
 
-      {group && wizard_open && (
+      {wizard_open && (
         <Modal is_open={wizard_open} on_close={close_wizard} size="md" close_on_overlay={false}>
           {wizard_step === 1 && (
             <>

--- a/src/components/settings/connect_provider_modal.tsx
+++ b/src/components/settings/connect_provider_modal.tsx
@@ -260,7 +260,7 @@ export function ConnectProviderModal({
   };
 
   return (
-    <Modal is_open={provider !== null} size="md" on_close={on_close}>
+    <Modal is_open={true} size="md" on_close={on_close}>
       <ModalBody className="p-0">
         <div className="flex flex-col items-center px-8 pt-10 pb-8">
           <div className="flex items-center justify-center gap-5 mb-8">

--- a/src/components/tags/tag_picker.tsx
+++ b/src/components/tags/tag_picker.tsx
@@ -85,7 +85,6 @@ export function TagPicker({
     <>
       <div className="fixed inset-0 z-40" onClick={on_close} />
       <AnimatePresence>
-        {is_open && (
           <motion.div
             animate={{ opacity: 1, y: 0 }}
             className="fixed z-50 w-64 rounded-lg border overflow-hidden bg-modal-bg border-edge-primary"
@@ -158,7 +157,6 @@ export function TagPicker({
               </button>
             </div>
           </motion.div>
-        )}
       </AnimatePresence>
 
       <CreateTagModal

--- a/src/hooks/use_editor_image.ts
+++ b/src/hooks/use_editor_image.ts
@@ -91,30 +91,26 @@ export function use_editor_image(
         let dy = move_e.clientY - start_y;
 
         let new_width = start_width;
-        let new_height = start_height;
 
         if (handle.includes("e")) {
           new_width = Math.max(
             min_width,
             Math.min(max_width, start_width + dx),
           );
-          new_height = new_width / aspect_ratio;
         } else if (handle.includes("w")) {
           new_width = Math.max(
             min_width,
             Math.min(max_width, start_width - dx),
           );
-          new_height = new_width / aspect_ratio;
         } else if (handle.includes("s")) {
-          new_height = Math.max(min_width / aspect_ratio, start_height + dy);
+          const new_height = Math.max(min_width / aspect_ratio, start_height + dy);
           new_width = new_height * aspect_ratio;
         } else if (handle.includes("n")) {
-          new_height = Math.max(min_width / aspect_ratio, start_height - dy);
+          const new_height = Math.max(min_width / aspect_ratio, start_height - dy);
           new_width = new_height * aspect_ratio;
         }
 
         new_width = Math.max(min_width, Math.min(max_width, new_width));
-        new_height = new_width / aspect_ratio;
 
         img.style.width = `${Math.round(new_width)}px`;
         img.style.height = "auto";

--- a/src/services/crypto/encrypted_drafts.ts
+++ b/src/services/crypto/encrypted_drafts.ts
@@ -67,6 +67,7 @@ interface DraftContext {
   reply_to_id?: string;
   forward_from_id?: string;
   pending_save: Promise<void> | null;
+  save_seq: number;
   last_content_hash: string | null;
   is_deleted: boolean;
 }
@@ -125,6 +126,7 @@ class DraftManager {
       reply_to_id,
       forward_from_id,
       pending_save: null,
+      save_seq: 0,
       last_content_hash: null,
       is_deleted: false,
     });
@@ -148,6 +150,7 @@ class DraftManager {
       reply_to_id,
       forward_from_id,
       pending_save: null,
+      save_seq: 0,
       last_content_hash: null,
       is_deleted: false,
     });
@@ -352,6 +355,7 @@ class DraftManager {
       }
     })();
 
+    const save_seq = ++context.save_seq;
     context.pending_save = save_promise;
 
     try {
@@ -368,7 +372,7 @@ class DraftManager {
         error: error instanceof Error ? error.message : "Failed to save draft",
       };
     } finally {
-      if (context.pending_save === save_promise) {
+      if (context.save_seq === save_seq) {
         context.pending_save = null;
       }
     }

--- a/src/services/crypto/envelope.ts
+++ b/src/services/crypto/envelope.ts
@@ -33,7 +33,7 @@ export function normalize_envelope_from(
   from: unknown,
 ): { name: string; email: string } | null {
   if (!from) return null;
-  if (typeof from === "object" && from !== null && "email" in from) {
+  if (typeof from === "object" && "email" in from) {
     return from as { name: string; email: string };
   }
   if (typeof from === "string") {

--- a/src/services/crypto/ratchet_sync.ts
+++ b/src/services/crypto/ratchet_sync.ts
@@ -101,6 +101,7 @@ async function decrypt_state_from_server(
 }
 
 const sync_locks = new Map<string, Promise<number>>();
+const sync_lock_owners = new Map<string, symbol>();
 const known_server_versions = new Map<string, number>();
 
 const MAX_SYNC_ATTEMPTS = 4;
@@ -273,13 +274,16 @@ export async function sync_ratchet_to_server(
     return do_sync(ratchet, encryption_key, server_version);
   })();
 
+  const lock_owner = Symbol();
   sync_locks.set(conversation_id, run);
+  sync_lock_owners.set(conversation_id, lock_owner);
 
   try {
     return await run;
   } finally {
-    if (sync_locks.get(conversation_id) === run) {
+    if (sync_lock_owners.get(conversation_id) === lock_owner) {
       sync_locks.delete(conversation_id);
+      sync_lock_owners.delete(conversation_id);
     }
   }
 }

--- a/src/utils/export/mboxrd_transducer.ts
+++ b/src/utils/export/mboxrd_transducer.ts
@@ -48,7 +48,7 @@ export async function* mboxrd_quote(
   };
 
   for await (const chunk of source) {
-    let buf = append(pending, chunk);
+    const buf = append(pending, chunk);
     pending = new Uint8Array(0);
     const out_parts: Uint8Array[] = [];
     let i = 0;
@@ -58,7 +58,6 @@ export async function* mboxrd_quote(
           out_parts.push(enc.encode(">"));
         } else if (buf.length - i < FROM_BYTES.length + 8 && buf[i] === GT) {
           pending = buf.subarray(i);
-          buf = new Uint8Array(0);
           break;
         }
         at_line_start = false;


### PR DESCRIPTION
Resolves all 20 code-quality findings reported by the CodeQL `javascript-code-quality` suite on `main` (commit 0c6f4f1):

- Useless/trivial conditional (9): dropped conditions already guaranteed by earlier early-returns or short-circuits
- Useless assignment to local (6): removed dead writes; tightened let to const
- Missing await (2): reworked intentional promise-identity guards to a sequence counter (drafts) and a Symbol owner token (ratchet sync)
- Comparison between inconvertible types (2): removed redundant null comparisons after non-null narrowing
- Semicolon insertion (1): added missing semicolon

No behavior change. Verified locally: CodeQL re-scan reports 0 remaining quality findings, tsc clean, envelope + ratchet_sync tests 50/50.