### PR TITLE
fix(retention): standard Switch + badge on auto-clean card

### DIFF
--- a/src/components/settings/folder_retention_section.test.tsx
+++ b/src/components/settings/folder_retention_section.test.tsx
@@ -69,6 +69,19 @@ vi.mock("@aster/ui", () => ({
       {children}
     </button>
   ),
+  Switch: ({
+    checked,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    onCheckedChange: (v: boolean) => void;
+  }) => (
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.currentTarget.checked)}
+    />
+  ),
 }));
 
 vi.mock("@/components/ui/modal", () => ({

--- a/src/components/settings/folder_retention_section.tsx
+++ b/src/components/settings/folder_retention_section.tsx
@@ -20,7 +20,7 @@
 //
 import * as React from "react";
 import { PlusIcon, TrashIcon, ClockIcon } from "@heroicons/react/24/outline";
-import { Button } from "@aster/ui";
+import { Button, Switch } from "@aster/ui";
 
 import {
   Modal,
@@ -226,26 +226,20 @@ export function RetentionPolicyCard({
             <span className="text-[13px] font-medium text-txt-primary truncate">
               {folder_name}
             </span>
-            <span className="text-[10.5px] px-1.5 py-0.5 rounded bg-surf-secondary text-txt-tertiary flex-shrink-0">
+            <span className="aster_badge aster_badge_blue flex-shrink-0">
               {t("folder_retention.card_badge")}
             </span>
             {!policy.enabled && (
-              <span className="text-[11px] px-1.5 py-0.5 rounded bg-neutral-200 dark:bg-neutral-700 text-txt-tertiary">
+              <span className="aster_badge aster_badge_gray flex-shrink-0">
                 {t("folder_retention.disabled_badge")}
               </span>
             )}
           </div>
           <div className="text-xs text-txt-muted">{summary}</div>
         </button>
-        <label className="flex items-center cursor-pointer flex-shrink-0">
-          <input
-            type="checkbox"
-            className="sr-only peer"
-            checked={policy.enabled}
-            onChange={on_toggle}
-          />
-          <span className="relative w-9 h-5 rounded-full bg-neutral-300 dark:bg-neutral-600 peer-checked:bg-blue-500 transition-colors after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:w-4 after:h-4 after:rounded-full after:bg-white after:transition-transform peer-checked:after:translate-x-4" />
-        </label>
+        <div className="flex-shrink-0">
+          <Switch checked={policy.enabled} onCheckedChange={on_toggle} />
+        </div>
         <button
           type="button"
           onClick={on_delete}


### PR DESCRIPTION
Folder auto-clean policy card now uses the shared Switch from @aster/ui and the standard aster_badge classes (blue for Auto-clean, gray for disabled), matching the rest of settings.