### PR TITLE
fix(security): harden sanitizer strips against nested reconstruction

### DIFF
--- a/src/lib/html_sanitizer.ts
+++ b/src/lib/html_sanitizer.ts
@@ -121,13 +121,27 @@ const PREVIEW_FORBIDDEN_ELEMENTS =
 const PREVIEW_FORBIDDEN_REGEX =
   /<\/?(?:style|script|noscript|template|link|meta|base|iframe|object|embed)\b[^>]*>/gi;
 
+const PREVIEW_STYLE_BLOCK_REGEX = /<style[\s\S]*?<\/style\s*>/gi;
+
+function strip_until_stable(input: string, pattern: RegExp): string {
+  let previous: string;
+  let current = input;
+
+  do {
+    previous = current;
+    current = current.replace(pattern, "");
+  } while (current !== previous);
+
+  return current;
+}
+
 export function sanitize_preview_html(html: string): string {
   if (!html || typeof html !== "string") return "";
 
-  let working = html.replace(/<style[\s\S]*?<\/style\s*>/gi, "");
+  const working = strip_until_stable(html, PREVIEW_STYLE_BLOCK_REGEX);
 
   if (typeof DOMParser === "undefined") {
-    return working.replace(PREVIEW_FORBIDDEN_REGEX, "");
+    return strip_until_stable(working, PREVIEW_FORBIDDEN_REGEX);
   }
 
   try {
@@ -147,9 +161,10 @@ export function sanitize_preview_html(html: string): string {
 
     return doc.body ? doc.body.innerHTML : "";
   } catch {
-    return working
-      .replace(/<style[\s\S]*?<\/style\s*>/gi, "")
-      .replace(PREVIEW_FORBIDDEN_REGEX, "");
+    return strip_until_stable(
+      strip_until_stable(working, PREVIEW_STYLE_BLOCK_REGEX),
+      PREVIEW_FORBIDDEN_REGEX,
+    );
   }
 }
 

--- a/src/lib/html_sanitizer.xss.test.ts
+++ b/src/lib/html_sanitizer.xss.test.ts
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 
 import { sanitize_html, sanitize_preview_html } from "./html_sanitizer";
 import { sanitize_css_block, sanitize_style } from "./html_sanitizer_css";
@@ -343,6 +343,31 @@ describe("sanitize_preview_html (top-origin shadow sink)", () => {
     );
     expect(preview.toLowerCase()).toContain("data:image/png");
     expect(preview).toContain("body");
+  });
+});
+
+describe("sanitize_preview_html fixpoint fallback (no DOMParser)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("removes a script tag reconstructed by a single strip pass", () => {
+    vi.stubGlobal("DOMParser", undefined);
+    const preview = sanitize_preview_html("<scr<script>ipt>alert(1)x");
+    expect(preview.toLowerCase()).not.toContain("<script");
+  });
+
+  it("removes a style tag reconstructed by a single strip pass", () => {
+    vi.stubGlobal("DOMParser", undefined);
+    const preview = sanitize_preview_html("<sty<style>le media=all>x");
+    expect(preview.toLowerCase()).not.toContain("<style");
+  });
+
+  it("keeps benign text untouched in the fallback", () => {
+    vi.stubGlobal("DOMParser", undefined);
+    const preview = sanitize_preview_html("hello <b>world</b>");
+    expect(preview).toContain("hello");
+    expect(preview.toLowerCase()).toContain("<b>");
   });
 });
 

--- a/src/lib/html_sanitizer_utils.ts
+++ b/src/lib/html_sanitizer_utils.ts
@@ -173,7 +173,15 @@ export function strip_mso_conditionals(html: string): string {
 function strip_attribute_markup(value: string): string {
   if (value.indexOf("<") === -1) return value;
 
-  return value.replace(/<[^>]*>?/g, "");
+  let previous: string;
+  let result = value;
+
+  do {
+    previous = result;
+    result = result.replace(/<[^>]*>?/g, "");
+  } while (result !== previous);
+
+  return result;
 }
 
 export function sanitize_attribute(


### PR DESCRIPTION
## What

Clears all 5 open `js/incomplete-multi-character-sanitization` alerts (#107-#111) in `html_sanitizer.ts` / `html_sanitizer_utils.ts`.

## Why

`sanitize_preview_html` writes into a **top-origin** shadow root (`sandboxed_email_renderer.tsx`, `preload_cache.ts`), so its sanitization must be airtight. The regex fallbacks (the `DOMParser === undefined` branch, the `catch` branch, and `strip_attribute_markup`) removed tags in a single pass. A nested payload such as `<scr<script>ipt>` reconstructs a live `<script>` after one removal, so a single pass is provably incomplete.

## Change

Route every regex strip through `strip_until_stable`, which re-applies the replacement until the string stops changing (fixpoint). This only ever removes more markup and defeats nested reconstruction. The primary DOMParser + DOMPurify paths are untouched, so rendering of legitimate email is unchanged.

## Verification

- CodeQL `security-and-quality` re-scan on the patched tree: **0** `incomplete-multi-character-sanitization` findings (was 5), no new findings introduced.
- `tsc --noEmit` clean.
- Sanitizer suite: 67 pass incl. 3 new fallback regression tests; the single remaining failure (`keeps tables`) is a pre-existing happy-dom artifact, confirmed failing on the clean baseline too.

No deploy in this PR.