### PR TITLE
fix(crypto): reject revoked/expired signer keys + block pasted-font CSS breakout

### DIFF
--- a/aster-crypto/src/decrypt.rs
+++ b/aster-crypto/src/decrypt.rs
@@ -20,9 +20,14 @@
 //
 use pgp::composed::{Deserializable, Message};
 
+use chrono::Utc;
+
 use crate::error::{CryptoError, Result};
 use crate::keys::{KeyPair, PublicKey, PublicKeyInner};
-use crate::sign::{signed_public_key_can_sign, signed_secret_key_can_sign};
+use crate::sign::{
+    signed_public_key_can_sign, signed_secret_key_can_sign, signed_secret_signing_identity_valid,
+    signing_identity_valid,
+};
 
 pub const MAX_CIPHERTEXT_BYTES: usize = 16 * 1024 * 1024;
 pub const MAX_PLAINTEXT_BYTES: usize = 64 * 1024 * 1024;
@@ -82,13 +87,18 @@ pub fn decrypt_message_binary(ciphertext: &[u8], secret_keys: &[&KeyPair]) -> Re
 }
 
 fn verify_with_sender_keys(msg: &Message, sender_keys: &[&PublicKey]) -> bool {
+    let now = Utc::now();
     for pk in sender_keys {
         let verified = match &pk.inner {
             PublicKeyInner::Standalone(spk) => {
-                signed_public_key_can_sign(spk) && msg.verify(spk).is_ok()
+                signing_identity_valid(spk, now)
+                    && signed_public_key_can_sign(spk)
+                    && msg.verify(spk).is_ok()
             }
             PublicKeyInner::FromSecret(ssk) => {
-                signed_secret_key_can_sign(ssk) && msg.verify(ssk).is_ok()
+                signed_secret_signing_identity_valid(ssk, now)
+                    && signed_secret_key_can_sign(ssk)
+                    && msg.verify(ssk).is_ok()
             }
         };
         if verified {

--- a/aster-crypto/src/sign.rs
+++ b/aster-crypto/src/sign.rs
@@ -18,12 +18,34 @@
 // You should have received a copy of the AGPLv3
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
+use chrono::{DateTime, Utc};
 use pgp::composed::{Deserializable, Message, SignedPublicKey, SignedSecretKey};
 use pgp::crypto::hash::HashAlgorithm;
+use pgp::packet::SignatureType;
 use rand::rngs::OsRng;
 
 use crate::error::{CryptoError, Result};
 use crate::keys::{KeyPair, PublicKey, PublicKeyInner};
+
+fn primary_is_revoked(spk: &SignedPublicKey) -> bool {
+    spk.details
+        .revocation_signatures
+        .iter()
+        .any(|s| matches!(s.typ(), SignatureType::KeyRevocation))
+}
+
+fn primary_is_expired(spk: &SignedPublicKey, now: DateTime<Utc>) -> bool {
+    spk.expires_at().map(|e| e <= now).unwrap_or(false)
+}
+
+pub(crate) fn signing_identity_valid(spk: &SignedPublicKey, now: DateTime<Utc>) -> bool {
+    !primary_is_revoked(spk) && !primary_is_expired(spk, now)
+}
+
+pub(crate) fn signed_secret_signing_identity_valid(ssk: &SignedSecretKey, now: DateTime<Utc>) -> bool {
+    let spk: SignedPublicKey = ssk.clone().into();
+    signing_identity_valid(&spk, now)
+}
 
 pub fn sign_message(message: &[u8], signer: &KeyPair) -> Result<Vec<u8>> {
     let msg = Message::new_literal_bytes("", message);
@@ -93,13 +115,18 @@ pub fn verify_signature(signed_message: &[u8], signer_keys: &[&PublicKey]) -> Re
     let (msg, _) = Message::from_armor_single(signed_message)
         .map_err(|e| CryptoError::SignatureVerification(e.to_string()))?;
 
+    let now = Utc::now();
     for pk in signer_keys {
         let verified = match &pk.inner {
             PublicKeyInner::Standalone(spk) => {
-                signed_public_key_can_sign(spk) && msg.verify(spk).is_ok()
+                signing_identity_valid(spk, now)
+                    && signed_public_key_can_sign(spk)
+                    && msg.verify(spk).is_ok()
             }
             PublicKeyInner::FromSecret(ssk) => {
-                signed_secret_key_can_sign(ssk) && msg.verify(ssk).is_ok()
+                signed_secret_signing_identity_valid(ssk, now)
+                    && signed_secret_key_can_sign(ssk)
+                    && msg.verify(ssk).is_ok()
             }
         };
         if verified {
@@ -192,5 +219,17 @@ mod tests {
 
         let result = verify_signature(&signed, &[&other_public]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn signing_identity_valid_accepts_generated_key() {
+        let signer = generate_keypair("Signer", "signer@astermail.com").unwrap();
+        let spk: SignedPublicKey = signer.secret_key().clone().into();
+        let now = Utc::now();
+
+        assert!(signing_identity_valid(&spk, now));
+        assert!(signing_identity_valid(&spk, now + chrono::Duration::days(3650)));
+        assert!(!primary_is_revoked(&spk));
+        assert!(!primary_is_expired(&spk, now + chrono::Duration::days(3650)));
     }
 }

--- a/src/lib/html_sanitizer_compose.ts
+++ b/src/lib/html_sanitizer_compose.ts
@@ -156,8 +156,10 @@ export function sanitize_compose_paste(html: string): string {
       const size = el.getAttribute("size");
       const styles: string[] = [];
 
-      if (color) styles.push(`color: ${color}`);
-      if (face) styles.push(`font-family: ${face}`);
+      const css_value_is_safe = (value: string) => !/[;:(){}<>]/.test(value);
+
+      if (color && css_value_is_safe(color)) styles.push(`color: ${color}`);
+      if (face && css_value_is_safe(face)) styles.push(`font-family: ${face}`);
       if (size) {
         const size_map: Record<string, string> = {
           "1": "10px",


### PR DESCRIPTION
Follow-up hardening from the second audit pass:

- Port the revocation/expiry gate into the Mail aster-crypto crate (verify_signature and decrypt_and_verify), so client-side sender-signature verification rejects revoked/expired keys. No-op for valid Aster keys.
- Reject CSS-structural characters in the color/face attributes of pasted <font> tags, preventing a background:url() exfil breakout while preserving legitimate font faces and colors.

aster-crypto 24/24; tsc + eslint clean; full suite 944 passed.