### PR TITLE
fix(security): sanitize attachment download filenames

### DIFF
--- a/src/lib/attachment_utils.download_filename.test.ts
+++ b/src/lib/attachment_utils.download_filename.test.ts
@@ -1,0 +1,53 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { describe, it, expect } from "vitest";
+
+import { sanitize_download_filename } from "./attachment_utils";
+
+const RLO = String.fromCharCode(0x202e);
+const NUL = String.fromCharCode(0x00);
+
+describe("sanitize_download_filename", () => {
+  it("strips bidi override characters used for extension spoofing", () => {
+    const spoof = "invoice" + RLO + "gpj.exe";
+
+    expect(sanitize_download_filename(spoof)).toBe("invoicegpj.exe");
+  });
+
+  it("strips control characters", () => {
+    expect(sanitize_download_filename("a" + NUL + "b.txt")).toBe("ab.txt");
+  });
+
+  it("replaces path separators", () => {
+    expect(sanitize_download_filename("a/b\\c.txt")).toBe("a_b_c.txt");
+  });
+
+  it("preserves legitimate filenames", () => {
+    expect(sanitize_download_filename("Report 2024.pdf")).toBe(
+      "Report 2024.pdf",
+    );
+    expect(sanitize_download_filename("résumé.docx")).toBe("résumé.docx");
+  });
+
+  it("falls back to a default when everything is stripped", () => {
+    expect(sanitize_download_filename(RLO + RLO)).toBe("download");
+  });
+});

--- a/src/lib/attachment_utils.ts
+++ b/src/lib/attachment_utils.ts
@@ -87,6 +87,28 @@ export function is_previewable_pdf(content_type: string): boolean {
   return content_type === "application/pdf";
 }
 
+export function sanitize_download_filename(filename: string): string {
+  let cleaned = "";
+
+  for (const ch of filename) {
+    const code = ch.codePointAt(0) ?? 0;
+    const is_control = code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+    const is_bidi =
+      code === 0x200e ||
+      code === 0x200f ||
+      (code >= 0x202a && code <= 0x202e) ||
+      (code >= 0x2066 && code <= 0x2069);
+
+    if (is_control || is_bidi) continue;
+
+    cleaned += code === 0x2f || code === 0x5c ? "_" : ch;
+  }
+
+  cleaned = cleaned.trim();
+
+  return cleaned || "download";
+}
+
 export function truncate_filename(
   filename: string,
   max_length: number = 20,

--- a/src/pages/secure_view.tsx
+++ b/src/pages/secure_view.tsx
@@ -29,6 +29,7 @@ import { Button } from "@aster/ui";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
+import { sanitize_download_filename } from "@/lib/attachment_utils";
 import { use_i18n } from "@/lib/i18n/context";
 import { sanitize_html } from "@/lib/html_sanitizer";
 import { EMAIL_BODY_CSS } from "@/lib/email_body_styles";
@@ -339,7 +340,7 @@ export default function SecureViewPage() {
     const anchor = document.createElement("a");
 
     anchor.href = url;
-    anchor.download = filename;
+    anchor.download = sanitize_download_filename(filename);
     document.body.appendChild(anchor);
     anchor.click();
     document.body.removeChild(anchor);

--- a/src/services/crypto/attachment_crypto.ts
+++ b/src/services/crypto/attachment_crypto.ts
@@ -21,6 +21,7 @@
 import type { Attachment } from "@/components/compose/compose_shared";
 import { decrypt_aes_gcm_with_fallback } from "@/services/crypto/legacy_keks";
 import { get_attachment_key } from "@/services/crypto/inbound_attachment_keys";
+import { sanitize_download_filename } from "@/lib/attachment_utils";
 
 import {
   encrypt_envelope_with_bytes,
@@ -332,7 +333,7 @@ export function download_decrypted_attachment(
   const link = document.createElement("a");
 
   link.href = url;
-  link.download = filename;
+  link.download = sanitize_download_filename(filename);
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);

--- a/src/services/export/destination.ts
+++ b/src/services/export/destination.ts
@@ -19,6 +19,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
 import { build_store_zip } from "@/utils/export/zip";
+import { sanitize_download_filename } from "@/lib/attachment_utils";
 
 interface ZipEntry {
   name: string;
@@ -186,7 +187,7 @@ export function trigger_download(blob: Blob, filename: string): void {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = filename;
+  a.download = sanitize_download_filename(filename);
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);


### PR DESCRIPTION
Strip Unicode bidirectional-override and control characters and neutralize path separators from attacker-controlled attachment filenames before assigning to the download anchor, preventing RTLO extension-spoofing lures (e.g. invoice<RLO>gpj.exe displaying as invoicegpj.exe). Applied to the three download paths (attachment_crypto, export destination, secure_view). Legitimate filenames (including unicode letters) are preserved. Adds unit tests (5/5); full suite 949 passed.