### PR TITLE
fix(security): case-insensitive URL scheme + CSS url() newline in email sanitizer

### DIFF
--- a/src/lib/html_sanitizer.remote_image_attrs.test.ts
+++ b/src/lib/html_sanitizer.remote_image_attrs.test.ts
@@ -63,6 +63,25 @@ describe("remote image attribute leaks (srcset / background)", () => {
     expect(result.external_content.blocked_count).toBeGreaterThan(0);
   });
 
+  it("treats an uppercase URL scheme as remote and blocks it", () => {
+    const result = sanitize_html(
+      `${LEAD}<img src="HTTP://tracker.example.com/leak.png" alt="pic">`,
+      { external_content_mode: "never", image_proxy_url: PROXY },
+    );
+
+    expect(result.external_content.has_remote_images).toBe(true);
+    expect(result.external_content.blocked_count).toBeGreaterThan(0);
+  });
+
+  it("routes an uppercase-scheme remote image through the proxy when auto-loading", () => {
+    const result = sanitize_html(
+      `${LEAD}<img src="HTTP://tracker.example.com/leak.png" alt="pic">`,
+      { external_content_mode: "always", image_proxy_url: PROXY },
+    );
+
+    expect(result.html).toContain(`${PROXY}?url=`);
+  });
+
   it("routes a remote background through the proxy when auto-loading", () => {
     const result = sanitize_html(
       `${LEAD}<table><tr><td background="${TRACKER}">cell</td></tr></table>`,

--- a/src/lib/html_sanitizer.ts
+++ b/src/lib/html_sanitizer.ts
@@ -566,8 +566,12 @@ function sanitize_html_impl(
         new_element.setAttribute("target", "_blank");
       }
       const href = new_element.getAttribute("href");
+      const lower_href = (href || "").toLowerCase().trim();
 
-      if (href && (href.startsWith("http://") || href.startsWith("https://"))) {
+      if (
+        href &&
+        (lower_href.startsWith("http://") || lower_href.startsWith("https://"))
+      ) {
         const strip_result = strip_tracking_params(href);
 
         new_element.setAttribute("href", strip_result.url);
@@ -589,7 +593,8 @@ function sanitize_html_impl(
     if (tag_name === "img") {
       let src = new_element.getAttribute("src") || "";
       const lower_src = src.toLowerCase().trim();
-      const is_remote = src.startsWith("http://") || src.startsWith("https://");
+      const is_remote =
+        lower_src.startsWith("http://") || lower_src.startsWith("https://");
       const is_data_url = lower_src.startsWith("data:");
       const is_pixel = is_tracking_pixel(new_element as HTMLImageElement);
 
@@ -603,7 +608,7 @@ function sanitize_html_impl(
         }
       }
 
-      if (is_remote && !is_first_party && src.startsWith("http://")) {
+      if (is_remote && !is_first_party && lower_src.startsWith("http://")) {
         src = "https://" + src.slice(7);
         new_element.setAttribute("src", src);
       }

--- a/src/lib/html_sanitizer_css.ts
+++ b/src/lib/html_sanitizer_css.ts
@@ -83,7 +83,7 @@ export function escape_style_terminator(css: string): string {
 export function strip_css_urls(css: string): string {
   const decoded = decode_css_escapes(css);
   return decoded.replace(
-    /url\s*\(\s*["']?(.*?)["']?\s*\)/gi,
+    /url\s*\(\s*["']?([\s\S]*?)["']?\s*\)/gi,
     (_match, url_content) => {
       const trimmed = (url_content || "").trim().toLowerCase();
 

--- a/src/pages/secure_view.tsx
+++ b/src/pages/secure_view.tsx
@@ -344,7 +344,7 @@ export default function SecureViewPage() {
     document.body.appendChild(anchor);
     anchor.click();
     document.body.removeChild(anchor);
-    URL.revokeObjectURL(url);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
   };
 
   const render_meta = () => {


### PR DESCRIPTION
Two anti-tracking sanitizer hardening fixes plus a download reliability fix:
- Compute is_remote / href checks against the lowercased URL so an uppercase scheme (HTTP://) can no longer bypass remote-image blocking, the image proxy, and tracking-pixel detection. Adds unit tests (uppercase image blocked + proxied).
- Match CSS url() across newlines when stripping remote refs ([\s\S] instead of .).
- secure_view: defer the download object-URL revoke by 1s to avoid truncating large downloads.
Full suite 955 passed; tsc + eslint clean.