### PR TITLE
fix(auth): ignore token refresh that resolves during intentional logout

### DIFF
--- a/src/services/api/client.ts
+++ b/src/services/api/client.ts
@@ -630,6 +630,10 @@ class ApiClient {
           refresh_token?: string;
         }>("/core/v1/auth/refresh", body);
 
+        if (this.intentional_logout) {
+          return;
+        }
+
         if (response.data?.csrf_token) {
           this.is_authenticated_flag = true;
           this.last_refresh_timestamp = Date.now();


### PR DESCRIPTION
A token refresh whose network call was in-flight when the user logged out would apply its result (repopulating the persistent Tauri/native token stores), resurrecting a valid session that the next launch would treat as authenticated. Guard: after the refresh response returns, bail if intentional_logout was set in the meantime. Does not touch the login path (login does not go through refresh_session_impl), so login-after-logout is unaffected. tsc + full suite (955) green.