### PR TITLE
fix(security): treat schemeless (//) URLs as remote in the email sanitizer

### DIFF
--- a/src/lib/html_sanitizer.remote_image_attrs.test.ts
+++ b/src/lib/html_sanitizer.remote_image_attrs.test.ts
@@ -82,6 +82,36 @@ describe("remote image attribute leaks (srcset / background)", () => {
     expect(result.html).toContain(`${PROXY}?url=`);
   });
 
+  it("treats a protocol-relative (schemeless) img url as remote and blocks it", () => {
+    const result = sanitize_html(
+      `${LEAD}<img src="//tracker.example.com/leak.png" alt="pic">`,
+      { external_content_mode: "never", image_proxy_url: PROXY },
+    );
+
+    expect(result.external_content.has_remote_images).toBe(true);
+    expect(result.external_content.blocked_count).toBeGreaterThan(0);
+  });
+
+  it("routes a schemeless img url through the proxy when auto-loading", () => {
+    const result = sanitize_html(
+      `${LEAD}<img src="//tracker.example.com/leak.png" alt="pic">`,
+      { external_content_mode: "always", image_proxy_url: PROXY },
+    );
+
+    expect(result.html).toContain(`${PROXY}?url=`);
+    expect(result.html).not.toContain('src="//tracker.example.com');
+  });
+
+  it("blocks a schemeless background attribute when remote images are blocked", () => {
+    const result = sanitize_html(
+      `${LEAD}<table><tr><td background="//tracker.example.com/b.png">c</td></tr></table>`,
+      { external_content_mode: "never", image_proxy_url: PROXY },
+    );
+
+    expect(result.external_content.has_remote_images).toBe(true);
+    expect(result.html.toLowerCase()).not.toContain("tracker.example.com");
+  });
+
   it("routes a remote background through the proxy when auto-loading", () => {
     const result = sanitize_html(
       `${LEAD}<table><tr><td background="${TRACKER}">cell</td></tr></table>`,

--- a/src/lib/html_sanitizer.ts
+++ b/src/lib/html_sanitizer.ts
@@ -526,7 +526,7 @@ function sanitize_html_impl(
         ) {
           sanitized_value = strip_css_urls(sanitized_value);
         } else if (attr_lower === "srcset") {
-          if (!lockdown_mode && /https?:\/\//i.test(sanitized_value)) {
+          if (!lockdown_mode && /(?:https?:)?\/\//i.test(sanitized_value)) {
             external_content.has_remote_images = true;
             if (block_images) {
               external_content.blocked_count++;
@@ -541,7 +541,7 @@ function sanitize_html_impl(
           if (lockdown_mode) {
             continue;
           }
-          if (/https?:\/\//i.test(sanitized_value)) {
+          if (/(?:https?:)?\/\//i.test(sanitized_value)) {
             external_content.has_remote_images = true;
             if (block_images) {
               external_content.blocked_count++;
@@ -594,7 +594,9 @@ function sanitize_html_impl(
       let src = new_element.getAttribute("src") || "";
       const lower_src = src.toLowerCase().trim();
       const is_remote =
-        lower_src.startsWith("http://") || lower_src.startsWith("https://");
+        lower_src.startsWith("http://") ||
+        lower_src.startsWith("https://") ||
+        lower_src.startsWith("//");
       const is_data_url = lower_src.startsWith("data:");
       const is_pixel = is_tracking_pixel(new_element as HTMLImageElement);
 
@@ -610,6 +612,9 @@ function sanitize_html_impl(
 
       if (is_remote && !is_first_party && lower_src.startsWith("http://")) {
         src = "https://" + src.slice(7);
+        new_element.setAttribute("src", src);
+      } else if (is_remote && !is_first_party && lower_src.startsWith("//")) {
+        src = "https:" + src.trim();
         new_element.setAttribute("src", src);
       }
 


### PR DESCRIPTION
Protocol-relative image URLs (<img src="//tracker/x.png">, and the background attribute) bypassed remote-image blocking, the image proxy, and tracking-pixel detection because remote-detection keyed on a literal http/https prefix. A malicious sender could leak the victim's IP + read receipt on message open, defeating both the proxy and the user's 'block remote images' setting. Now schemeless URLs are classified remote (img/background/srcset) and normalized to https for the proxy. Same class as the earlier uppercase-scheme fix. Adds 3 unit tests (blocked in never-mode, proxied in always-mode); full suite 958 passed, tsc + eslint clean.