### PR TITLE
fix(mail): keep email open when Escape closes attachment overlays

### DIFF
--- a/src/components/common/encryption_info_dropdown.tsx
+++ b/src/components/common/encryption_info_dropdown.tsx
@@ -64,14 +64,16 @@ export function EncryptionInfoDropdown({
 
     const handle_escape = (event: KeyboardEvent) => {
       if (event["key"] === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
         set_is_open(false);
       }
     };
 
-    document.addEventListener("keydown", handle_escape);
+    window.addEventListener("keydown", handle_escape, true);
 
     return () => {
-      document.removeEventListener("keydown", handle_escape);
+      window.removeEventListener("keydown", handle_escape, true);
     };
   }, [is_open]);
 

--- a/src/components/email/attachment_list.tsx
+++ b/src/components/email/attachment_list.tsx
@@ -170,14 +170,18 @@ function ImagePreviewModal({
 
   useEffect(() => {
     const handle_key = (e: KeyboardEvent) => {
-      if (e.key === "Escape") on_close();
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        on_close();
+      }
     };
 
-    document.addEventListener("keydown", handle_key);
+    window.addEventListener("keydown", handle_key, true);
     document.body.style.overflow = "hidden";
 
     return () => {
-      document.removeEventListener("keydown", handle_key);
+      window.removeEventListener("keydown", handle_key, true);
       document.body.style.overflow = "";
     };
   }, [on_close]);

--- a/src/components/email/external_content_banner.tsx
+++ b/src/components/email/external_content_banner.tsx
@@ -158,7 +158,11 @@ export function ExternalContentBanner({
     };
 
     const handle_escape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") set_is_open(false);
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        set_is_open(false);
+      }
     };
 
     const handle_blur = () => {
@@ -166,12 +170,12 @@ export function ExternalContentBanner({
     };
 
     document.addEventListener("mousedown", handle_click_outside);
-    document.addEventListener("keydown", handle_escape);
+    window.addEventListener("keydown", handle_escape, true);
     window.addEventListener("blur", handle_blur);
 
     return () => {
       document.removeEventListener("mousedown", handle_click_outside);
-      document.removeEventListener("keydown", handle_escape);
+      window.removeEventListener("keydown", handle_escape, true);
       window.removeEventListener("blur", handle_blur);
     };
   }, [is_open]);

--- a/src/components/email/full_email_viewer.tsx
+++ b/src/components/email/full_email_viewer.tsx
@@ -297,7 +297,7 @@ export function FullEmailViewer({
 
   useEffect(() => {
     const handle_keyboard_back = (e: KeyboardEvent) => {
-      if (e["key"] === "Escape") {
+      if (e["key"] === "Escape" && !e.defaultPrevented) {
         on_back();
       }
     };

--- a/src/components/email/hooks/use_popup_viewer.ts
+++ b/src/components/email/hooks/use_popup_viewer.ts
@@ -230,7 +230,7 @@ export function use_popup_viewer({
 
   useEffect(() => {
     const handle_escape = (e: KeyboardEvent) => {
-      if (e["key"] === "Escape") {
+      if (e["key"] === "Escape" && !e.defaultPrevented) {
         e.preventDefault();
         e.stopPropagation();
         on_close();

--- a/src/components/email/pdf_preview_modal.tsx
+++ b/src/components/email/pdf_preview_modal.tsx
@@ -200,14 +200,18 @@ export function PdfPreviewModal({
 
   useEffect(() => {
     const handle_key = (e: KeyboardEvent) => {
-      if (e.key === "Escape") on_close();
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        on_close();
+      }
     };
 
-    document.addEventListener("keydown", handle_key);
+    window.addEventListener("keydown", handle_key, true);
     document.body.style.overflow = "hidden";
 
     return () => {
-      document.removeEventListener("keydown", handle_key);
+      window.removeEventListener("keydown", handle_key, true);
       document.body.style.overflow = "";
     };
   }, [on_close]);

--- a/src/components/email/sandboxed_email_renderer.tsx
+++ b/src/components/email/sandboxed_email_renderer.tsx
@@ -1294,12 +1294,16 @@ ${link_underline_css ? `<style>${link_underline_css}</style>` : ""}
   useEffect(() => {
     if (!zoomed_image) return;
     const handle_key = (e: KeyboardEvent) => {
-      if (e.key === "Escape") set_zoomed_image(null);
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        set_zoomed_image(null);
+      }
     };
 
-    window.addEventListener("keydown", handle_key);
+    window.addEventListener("keydown", handle_key, true);
 
-    return () => window.removeEventListener("keydown", handle_key);
+    return () => window.removeEventListener("keydown", handle_key, true);
   }, [zoomed_image]);
 
   const effective_bg = is_html_email ? html_bg : plain_bg;


### PR DESCRIPTION
User report (Jesper): clicking to download an attachment starts the download, then the app exits the email back to the inbox, forcing a reopen and a slow attachment re-decrypt.

Root cause: the app-level keyboard shortcuts hook (use_keyboard_shortcuts) listens for keydown on document in the CAPTURE phase and maps Escape to close_viewer. Its is_any_modal_open guard knows nothing about the attachment preview overlays, and because it registers at app mount its capture listener runs before any overlay listener registered later. So when a user opens an image/PDF preview, clicks Download, and presses Escape to dismiss the preview, one keypress closes the preview AND the open email. The full_email_viewer window-level Escape listener duplicated the same behavior.

Fix - topmost layer wins:
- Overlay Escape handlers (image preview modal, PDF preview modal, zoomed inline image, external content banner dropdown, encryption info dropdown) now listen on window in the capture phase - which runs before document-capture regardless of registration order - and consume the event (preventDefault + stopPropagation) before closing only themselves.
- full_email_viewer and use_popup_viewer ignore Escape events whose default was already prevented.
- Reply/forward modals already consumed Escape correctly and are untouched.

Verified end to end against the local dev stack (Vite + local astermail_backend) with Playwright, before and after:
- Before: preview open + Download + Escape reproduced the exact bug (location.hash cleared, viewer closed back to inbox).
- After, 9/9 checks pass for the image path: card download keeps viewer open; preview download + Escape closes only the preview (hash unchanged); a second Escape still closes the viewer; Escape with no overlay still closes the viewer.
- PDF path verified separately end to end (compose + self-send a PDF, open, preview, download, Escape): 5/5 checks pass.
- tsc --noEmit clean.