### PR TITLE
feat(review): one-time review prompt, plus web manifest fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN addgroup -g 1001 -S appgroup && \
 
 RUN sed -i 's|application/javascript\s*js;|application/javascript js mjs;|' /etc/nginx/mime.types
 
+RUN grep -q webmanifest /etc/nginx/mime.types || \
+    sed -i 's|application/json  *json;|application/json                       json;\n    application/manifest+json             webmanifest;|' /etc/nginx/mime.types
+
 RUN mkdir -p /etc/nginx/secret && \
     printf 'map $is_onion $onion_auth_header { default ""; }\n' > /etc/nginx/secret/onion_secret_map.conf && \
     chown -R appuser:appgroup /etc/nginx/secret

--- a/src/components/compose/compose_send_actions.ts
+++ b/src/components/compose/compose_send_actions.ts
@@ -40,6 +40,7 @@ import { show_toast } from "@/components/toast/simple_toast";
 import { show_action_toast } from "@/components/toast/action_toast";
 import { invalidate_mail_stats } from "@/hooks/use_mail_stats";
 import { emit_email_sent } from "@/hooks/mail_events";
+import { record_review_prompt_action } from "@/lib/review_prompt";
 
 export interface SendActionContext {
   undo_send_enabled: boolean;
@@ -170,6 +171,7 @@ export async function execute_internal_send(
           dispatch_email_sent();
           log_activities_for_sent(ctx, email_data);
           ctx.on_close();
+          record_review_prompt_action();
           show_action_toast({
             message: ctx.t("common.email_sent"),
             action_type: "read",
@@ -222,6 +224,7 @@ export async function execute_internal_send(
           clear_stash(ctx);
           dispatch_email_sent();
           log_activities_for_sent(ctx, email_data);
+          record_review_prompt_action();
           show_action_toast({
             message: ctx.t("common.email_sent"),
             action_type: "read",
@@ -353,6 +356,7 @@ export async function execute_external_email_send(
         dispatch_email_sent();
         log_activities_for_sent(ctx, email_data);
         ctx.on_close();
+        record_review_prompt_action();
         show_action_toast({
           message: ctx.t("common.email_sent"),
           action_type: "read",
@@ -419,6 +423,7 @@ export async function execute_external_email_send(
       if (ctx.edit_draft && ctx.on_draft_cleared) {
         ctx.on_draft_cleared();
       }
+      record_review_prompt_action();
       show_action_toast({
         message: ctx.t("common.email_sent"),
         action_type: "read",
@@ -498,6 +503,7 @@ export async function execute_external_account_email_send(
           log_activities_for_sent(ctx, email_data);
           ctx.on_close();
           show_toast(ctx.t("common.email_sent"), "success");
+          record_review_prompt_action();
         } else {
           show_toast(
             result.error || ctx.t("common.failed_to_send_email"),
@@ -548,6 +554,7 @@ export async function execute_external_account_email_send(
             log_activities_for_sent(ctx, email_data);
             ctx.on_close();
             show_toast(ctx.t("common.email_sent"), "success");
+            record_review_prompt_action();
           } else {
             show_toast(
               result.error || ctx.t("common.failed_to_send_email"),
@@ -588,6 +595,7 @@ export async function execute_external_account_email_send(
     }
 
     show_toast(ctx.t("common.email_sent"), "success");
+    record_review_prompt_action();
     dispatch_email_sent();
     log_activities_for_sent(ctx, email_data);
 

--- a/src/components/email/email_reply_section.tsx
+++ b/src/components/email/email_reply_section.tsx
@@ -46,6 +46,7 @@ import { is_system_email } from "@/lib/utils";
 import { use_should_reduce_motion } from "@/provider";
 import { get_aster_footer } from "@/components/compose/compose_shared";
 import { Spinner } from "@/components/ui/spinner";
+import { record_review_prompt_action } from "@/lib/review_prompt";
 
 type SendState = "idle" | "queued" | "sending" | "sent" | "error";
 
@@ -179,6 +180,7 @@ export function EmailReplySection({
           set_send_state("sent");
           if (!undo_enabled) {
             show_toast(t("common.email_sent"), "success");
+            record_review_prompt_action();
           }
           setTimeout(() => {
             set_reply_text("");
@@ -265,9 +267,7 @@ export function EmailReplySection({
           disabled={is_system_email(email)}
           style={{
             opacity: is_system_email(email) ? 0.6 : 1,
-            cursor: is_system_email(email)
-              ? "not-allowed"
-              : "pointer",
+            cursor: is_system_email(email) ? "not-allowed" : "pointer",
           }}
           whileHover={
             is_system_email(email)
@@ -279,9 +279,7 @@ export function EmailReplySection({
                 }
           }
           onClick={
-            is_system_email(email)
-              ? undefined
-              : () => set_show_reply_menu(true)
+            is_system_email(email) ? undefined : () => set_show_reply_menu(true)
           }
         >
           {t("mail.reply")}

--- a/src/components/modals/hooks/use_forward_modal/hook.ts
+++ b/src/components/modals/hooks/use_forward_modal/hook.ts
@@ -125,6 +125,7 @@ import {
 } from "@/utils/date_format";
 import { use_escape_layer } from "@/lib/overlay_layer_stack";
 import { user_facing_error } from "@/utils/user_facing_error";
+import { record_review_prompt_action } from "@/lib/review_prompt";
 
 export function use_forward_modal({
   is_open,
@@ -715,6 +716,7 @@ export function use_forward_modal({
       is_sending_ref.current = false;
       send_lock_started_at_ref.current = 0;
       show_toast(t("common.email_sent"), "success");
+      record_review_prompt_action();
       on_close();
 
       return;
@@ -787,6 +789,7 @@ export function use_forward_modal({
           setTimeout(() => {
             emit_email_sent();
           }, 100);
+          record_review_prompt_action();
           show_action_toast({
             message: t("common.email_sent"),
             action_type: "read",

--- a/src/components/onboarding/recovery_reminder.tsx
+++ b/src/components/onboarding/recovery_reminder.tsx
@@ -107,21 +107,18 @@ export function RecoveryReminder({
             }}
             transition={{ duration, ease: "easeOut" }}
           >
-            <div
-              className="flex h-10 w-10 items-center justify-center rounded-full"
-              style={{ backgroundColor: "var(--accent-color-fade, #2563eb1a)" }}
-            >
+            <div className="flex items-center gap-2.5">
               <KeyIcon
-                className="h-5 w-5"
-                style={{ color: "var(--accent-color)" }}
+                aria-hidden="true"
+                className="h-5 w-5 flex-shrink-0 text-txt-primary"
+                strokeWidth={1.75}
               />
+              <h2 className="text-base font-semibold text-txt-primary">
+                {t("common.recovery_reminder_title")}
+              </h2>
             </div>
 
-            <h2 className="mt-4 text-base font-semibold text-txt-primary">
-              {t("common.recovery_reminder_title")}
-            </h2>
-
-            <p className="mt-2 text-sm leading-relaxed text-txt-secondary">
+            <p className="mt-2.5 text-sm leading-relaxed text-txt-secondary">
               {t("common.recovery_reminder_body")}
             </p>
 

--- a/src/components/review/review_prompt_banner.tsx
+++ b/src/components/review/review_prompt_banner.tsx
@@ -18,26 +18,49 @@
 // You should have received a copy of the AGPLv3
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { StarIcon } from "@heroicons/react/24/outline";
 
 import { use_should_reduce_motion } from "@/provider";
 import { use_i18n } from "@/lib/i18n/context";
+import { use_preferences } from "@/contexts/preferences_context";
 import {
   REVIEW_PROMPT_URL,
+  is_review_prompt_due,
   mark_review_prompt_done,
-  should_show_review_prompt,
 } from "@/lib/review_prompt";
 
 export function ReviewPromptBanner() {
   const reduce_motion = use_should_reduce_motion();
   const { t } = use_i18n();
-  const [is_visible, set_is_visible] = useState(should_show_review_prompt);
+  const { preferences, update_preference, has_loaded_from_server } =
+    use_preferences();
+  const [is_visible, set_is_visible] = useState(false);
+  const is_done = preferences.review_prompt_web_done;
+
+  useEffect(() => {
+    if (!has_loaded_from_server || is_done) {
+      set_is_visible(false);
+
+      return;
+    }
+
+    let cancelled = false;
+
+    is_review_prompt_due().then((due) => {
+      if (!cancelled && due) set_is_visible(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [has_loaded_from_server, is_done]);
 
   const close = () => {
     set_is_visible(false);
     mark_review_prompt_done();
+    update_preference("review_prompt_web_done", true);
   };
 
   const pill_button = (

--- a/src/components/review/review_prompt_banner.tsx
+++ b/src/components/review/review_prompt_banner.tsx
@@ -1,0 +1,114 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { StarIcon } from "@heroicons/react/24/outline";
+
+import { use_should_reduce_motion } from "@/provider";
+import { use_i18n } from "@/lib/i18n/context";
+import {
+  REVIEW_PROMPT_URL,
+  mark_review_prompt_done,
+  should_show_review_prompt,
+} from "@/lib/review_prompt";
+
+export function ReviewPromptBanner() {
+  const reduce_motion = use_should_reduce_motion();
+  const { t } = use_i18n();
+  const [is_visible, set_is_visible] = useState(should_show_review_prompt);
+
+  const close = () => {
+    set_is_visible(false);
+    mark_review_prompt_done();
+  };
+
+  const pill_button = (
+    label: string,
+    on_click: () => void,
+    emphasis: boolean,
+    title?: string,
+  ) => (
+    <button
+      className="px-2.5 py-0.5 text-xs font-medium rounded-[12px] transition-colors"
+      style={{
+        backgroundColor: emphasis
+          ? "rgba(255, 255, 255, 0.2)"
+          : "rgba(255, 255, 255, 0.1)",
+        color: "inherit",
+      }}
+      title={title}
+      type="button"
+      onClick={on_click}
+      onMouseEnter={(e) =>
+        (e.currentTarget.style.backgroundColor = emphasis
+          ? "rgba(255, 255, 255, 0.3)"
+          : "rgba(255, 255, 255, 0.2)")
+      }
+      onMouseLeave={(e) =>
+        (e.currentTarget.style.backgroundColor = emphasis
+          ? "rgba(255, 255, 255, 0.2)"
+          : "rgba(255, 255, 255, 0.1)")
+      }
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <AnimatePresence>
+      {is_visible && (
+        <motion.div
+          animate={{ opacity: 1, height: "auto" }}
+          className="w-full text-[var(--accent-fg,#ffffff)] flex-shrink-0 overflow-hidden"
+          exit={{ opacity: 0, height: 0, overflow: "hidden" }}
+          initial={reduce_motion ? false : { opacity: 0, height: 0 }}
+          style={{ backgroundColor: "var(--accent-color)" }}
+          transition={{ duration: reduce_motion ? 0 : 0.2 }}
+        >
+          <div className="flex items-center justify-between px-4 py-1.5">
+            <div className="flex items-center gap-1.5 min-w-0">
+              <StarIcon className="h-3.5 w-3.5 flex-shrink-0 opacity-90" />
+              <span className="text-xs font-medium truncate opacity-95">
+                {t("review_prompt.banner_message")}
+              </span>
+            </div>
+            <div className="flex items-center gap-1.5 flex-shrink-0 ms-4">
+              {pill_button(
+                t("review_prompt.banner_open"),
+                () => {
+                  window.open(
+                    REVIEW_PROMPT_URL,
+                    "_blank",
+                    "noopener,noreferrer",
+                  );
+                  close();
+                },
+                true,
+                t("review_prompt.opens_in_new_tab"),
+              )}
+              {pill_button(t("review_prompt.banner_dismiss"), close, false)}
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/survey/survey_banner.tsx
+++ b/src/components/survey/survey_banner.tsx
@@ -52,7 +52,11 @@ function cache_done() {
   }
 }
 
-export function SurveyBanner() {
+export function SurveyBanner({
+  on_visibility_change,
+}: {
+  on_visibility_change?: (is_visible: boolean) => void;
+} = {}) {
   const reduce_motion = use_should_reduce_motion();
   const { t } = use_i18n();
   const [status, set_status] = useState<SurveyStatusResponse | null>(null);
@@ -77,6 +81,10 @@ export function SurveyBanner() {
   }, []);
 
   const should_hide = is_hidden || !status?.eligible;
+
+  useEffect(() => {
+    on_visibility_change?.(!should_hide);
+  }, [should_hide, on_visibility_change]);
 
   const handle_remind_tomorrow = () => {
     set_is_hidden(true);

--- a/src/hooks/use_tags.stale_fetch.test.ts
+++ b/src/hooks/use_tags.stale_fetch.test.ts
@@ -96,6 +96,20 @@ async function flush(): Promise<void> {
   });
 }
 
+async function flush_until(is_done: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    await flush();
+
+    if (is_done()) return;
+  }
+}
+
+async function flush_times(count: number): Promise<void> {
+  for (let attempt = 0; attempt < count; attempt++) {
+    await flush();
+  }
+}
+
 describe("use_tags stale fetch", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -168,14 +182,14 @@ describe("use_tags stale fetch", () => {
     await act(async () => {
       resolve_new(["fresh"]);
     });
-    await flush();
+    await flush_until(() => names.length > 0);
 
     expect(names).toEqual(["fresh"]);
 
     await act(async () => {
       resolve_old(["stale"]);
     });
-    await flush();
+    await flush_times(8);
 
     expect(names).toEqual(["fresh"]);
   });

--- a/src/lib/i18n/translations/ar.ts
+++ b/src/lib/i18n/translations/ar.ts
@@ -4248,10 +4248,8 @@ export const ar = {
       "سيتم توجيهك إلى مزود الدفع الآمن لإتمام عملية الشراء.",
     billing_unavailable:
       "المدفوعات غير متاحة مؤقتًا. أعد المحاولة بعد بضع دقائق.",
-    checkout_rate_limited:
-      "محاولات كثيرة جدًا. انتظر دقيقة ثم أعد المحاولة.",
-    checkout_already_active:
-      "لديك اشتراك نشط بالفعل. حدّث الصفحة لعرضه.",
+    checkout_rate_limited: "محاولات كثيرة جدًا. انتظر دقيقة ثم أعد المحاولة.",
+    checkout_already_active: "لديك اشتراك نشط بالفعل. حدّث الصفحة لعرضه.",
     plan_not_available:
       "هذه الخطة غير متاحة للشراء حاليًا. خطة أخرى أو العودة لاحقًا ستعمل.",
     failed_checkout:
@@ -9565,6 +9563,13 @@ export const ar = {
       "هل تريد حذف {{address}}؟ سيتوقف العنوان عن استقبال البريد ولا يمكن تسجيله مجددًا.",
     delete_confirm_title: "حذف صندوق البريد المشترك",
     access_unavailable: "صندوق البريد المشترك هذا لم يعد متاحًا",
+  },
+  review_prompt: {
+    banner_message:
+      "يمكنك تقييم Aster Mail على Trustpilot. التقييمات علنية، وتظهر لك هذه الرسالة مرة واحدة فقط.",
+    banner_open: "فتح Trustpilot",
+    banner_dismiss: "لا، شكرًا",
+    opens_in_new_tab: "يفتح Trustpilot في علامة تبويب جديدة",
   },
   survey: {
     banner_title: "ساعدنا في تحسين Aster Mail",

--- a/src/lib/i18n/translations/de.ts
+++ b/src/lib/i18n/translations/de.ts
@@ -9872,6 +9872,13 @@ export const de = {
     delete_confirm_title: "Geteiltes Postfach löschen",
     access_unavailable: "Dieses geteilte Postfach ist nicht mehr verfügbar",
   },
+  review_prompt: {
+    banner_message:
+      "Sie können Aster Mail auf Trustpilot bewerten. Bewertungen sind öffentlich, und Sie sehen diesen Hinweis nur einmal.",
+    banner_open: "Trustpilot öffnen",
+    banner_dismiss: "Nein, danke",
+    opens_in_new_tab: "Öffnet Trustpilot in einem neuen Tab",
+  },
   survey: {
     banner_title: "Hilf uns, Aster Mail zu verbessern",
     banner_message:

--- a/src/lib/i18n/translations/en.ts
+++ b/src/lib/i18n/translations/en.ts
@@ -3202,8 +3202,7 @@ export const en: Translations = {
       "You will be redirected to our secure payment provider to complete your purchase.",
     billing_unavailable:
       "Payments are temporarily unavailable. Try again in a few minutes.",
-    checkout_rate_limited:
-      "Too many attempts. Wait a minute, then try again.",
+    checkout_rate_limited: "Too many attempts. Wait a minute, then try again.",
     checkout_already_active:
       "You already have an active subscription. Refresh the page to see it.",
     plan_not_available:
@@ -9500,6 +9499,13 @@ export const en: Translations = {
       "Delete {{address}}? The address stops receiving mail and cannot be registered again.",
     delete_confirm_title: "Delete shared mailbox",
     access_unavailable: "This shared mailbox is no longer available",
+  },
+  review_prompt: {
+    banner_message:
+      "You can review Aster Mail on Trustpilot. Reviews are public, and you only see this once.",
+    banner_open: "Open Trustpilot",
+    banner_dismiss: "No thanks",
+    opens_in_new_tab: "Opens Trustpilot in a new tab",
   },
   survey: {
     banner_title: "Help shape Aster Mail",

--- a/src/lib/i18n/translations/es.ts
+++ b/src/lib/i18n/translations/es.ts
@@ -9579,6 +9579,13 @@ export const es = {
     delete_confirm_title: "Eliminar buzón compartido",
     access_unavailable: "Este buzón compartido ya no está disponible",
   },
+  review_prompt: {
+    banner_message:
+      "Puedes valorar Aster Mail en Trustpilot. Las opiniones son públicas y solo verás este aviso una vez.",
+    banner_open: "Abrir Trustpilot",
+    banner_dismiss: "No, gracias",
+    opens_in_new_tab: "Abre Trustpilot en una pestaña nueva",
+  },
   survey: {
     banner_title: "Ayúdanos a mejorar Aster Mail",
     banner_message:

--- a/src/lib/i18n/translations/fr.ts
+++ b/src/lib/i18n/translations/fr.ts
@@ -9705,6 +9705,13 @@ export const fr = {
     delete_confirm_title: "Supprimer la boîte partagée",
     access_unavailable: "Cette boîte partagée n'est plus disponible",
   },
+  review_prompt: {
+    banner_message:
+      "Vous pouvez évaluer Aster Mail sur Trustpilot. Les avis sont publics, et ce message ne s'affiche qu'une fois.",
+    banner_open: "Ouvrir Trustpilot",
+    banner_dismiss: "Non merci",
+    opens_in_new_tab: "Ouvre Trustpilot dans un nouvel onglet",
+  },
   survey: {
     banner_title: "Aidez-nous à améliorer Aster Mail",
     banner_message:

--- a/src/lib/i18n/translations/hi.ts
+++ b/src/lib/i18n/translations/hi.ts
@@ -9530,6 +9530,13 @@ export const hi = {
     delete_confirm_title: "साझा मेलबॉक्स हटाएं",
     access_unavailable: "यह साझा मेलबॉक्स अब उपलब्ध नहीं है",
   },
+  review_prompt: {
+    banner_message:
+      "आप Trustpilot पर Aster Mail की समीक्षा कर सकते हैं। समीक्षाएँ सार्वजनिक होती हैं, और यह संदेश आपको केवल एक बार दिखता है।",
+    banner_open: "Trustpilot खोलें",
+    banner_dismiss: "अभी नहीं",
+    opens_in_new_tab: "Trustpilot को नए टैब में खोलता है",
+  },
   survey: {
     banner_title: "Aster Mail को बेहतर बनाने में मदद करें",
     banner_message:

--- a/src/lib/i18n/translations/it.ts
+++ b/src/lib/i18n/translations/it.ts
@@ -4806,8 +4806,7 @@ export const it = {
       "Verrai reindirizzato al nostro fornitore di pagamento sicuro per completare l'acquisto.",
     billing_unavailable:
       "I pagamenti non sono disponibili al momento. Riprova tra qualche minuto.",
-    checkout_rate_limited:
-      "Troppi tentativi. Attendi un minuto, poi riprova.",
+    checkout_rate_limited: "Troppi tentativi. Attendi un minuto, poi riprova.",
     checkout_already_active:
       "Hai già un abbonamento attivo. Aggiorna la pagina per vederlo.",
     plan_not_available:
@@ -9776,6 +9775,13 @@ export const it = {
       "Eliminare {{address}}? L'indirizzo smetterà di ricevere posta e non potrà essere registrato di nuovo.",
     delete_confirm_title: "Elimina casella condivisa",
     access_unavailable: "Questa casella condivisa non è più disponibile",
+  },
+  review_prompt: {
+    banner_message:
+      "Puoi recensire Aster Mail su Trustpilot. Le recensioni sono pubbliche e vedi questo messaggio una sola volta.",
+    banner_open: "Apri Trustpilot",
+    banner_dismiss: "No, grazie",
+    opens_in_new_tab: "Apre Trustpilot in una nuova scheda",
   },
   survey: {
     banner_title: "Aiutaci a migliorare Aster Mail",

--- a/src/lib/i18n/translations/ja.ts
+++ b/src/lib/i18n/translations/ja.ts
@@ -9526,6 +9526,13 @@ export const ja = {
     delete_confirm_title: "共有メールボックスの削除",
     access_unavailable: "この共有メールボックスは利用できなくなりました",
   },
+  review_prompt: {
+    banner_message:
+      "Trustpilot で Aster Mail をレビューできます。レビューは公開され、このお知らせは一度だけ表示されます。",
+    banner_open: "Trustpilot を開く",
+    banner_dismiss: "今はしない",
+    opens_in_new_tab: "Trustpilot を新しいタブで開きます",
+  },
   survey: {
     banner_title: "Aster Mail の改善にご協力ください",
     banner_message:

--- a/src/lib/i18n/translations/ko.ts
+++ b/src/lib/i18n/translations/ko.ts
@@ -9243,6 +9243,13 @@ export const ko = {
     delete_confirm_title: "공유 메일함 삭제",
     access_unavailable: "이 공유 메일함은 더 이상 사용할 수 없습니다",
   },
+  review_prompt: {
+    banner_message:
+      "Trustpilot에서 Aster Mail을 평가할 수 있습니다. 리뷰는 공개되며 이 안내는 한 번만 표시됩니다.",
+    banner_open: "Trustpilot 열기",
+    banner_dismiss: "괜찮습니다",
+    opens_in_new_tab: "Trustpilot을 새 탭에서 엽니다",
+  },
   survey: {
     banner_title: "Aster Mail 개선에 도움을 주세요",
     banner_message:

--- a/src/lib/i18n/translations/nl.ts
+++ b/src/lib/i18n/translations/nl.ts
@@ -9645,6 +9645,13 @@ export const nl = {
     delete_confirm_title: "Gedeelde mailbox verwijderen",
     access_unavailable: "Deze gedeelde mailbox is niet meer beschikbaar",
   },
+  review_prompt: {
+    banner_message:
+      "Je kunt Aster Mail beoordelen op Trustpilot. Beoordelingen zijn openbaar en je ziet dit bericht maar één keer.",
+    banner_open: "Trustpilot openen",
+    banner_dismiss: "Nee, bedankt",
+    opens_in_new_tab: "Opent Trustpilot in een nieuw tabblad",
+  },
   survey: {
     banner_title: "Help Aster Mail te verbeteren",
     banner_message:

--- a/src/lib/i18n/translations/pl.ts
+++ b/src/lib/i18n/translations/pl.ts
@@ -9904,6 +9904,13 @@ export const pl = {
     delete_confirm_title: "Usuń wspólną skrzynkę",
     access_unavailable: "Ta wspólna skrzynka nie jest już dostępna",
   },
+  review_prompt: {
+    banner_message:
+      "Możesz ocenić Aster Mail w serwisie Trustpilot. Opinie są publiczne, a ten komunikat zobaczysz tylko raz.",
+    banner_open: "Otwórz Trustpilot",
+    banner_dismiss: "Nie, dziękuję",
+    opens_in_new_tab: "Otwiera Trustpilot w nowej karcie",
+  },
   survey: {
     banner_title: "Pomóż ulepszyć Aster Mail",
     banner_message:

--- a/src/lib/i18n/translations/pt.ts
+++ b/src/lib/i18n/translations/pt.ts
@@ -9722,6 +9722,13 @@ export const pt = {
     delete_confirm_title: "Excluir caixa compartilhada",
     access_unavailable: "Esta caixa compartilhada não está mais disponível",
   },
+  review_prompt: {
+    banner_message:
+      "Pode avaliar o Aster Mail no Trustpilot. As avaliações são públicas e esta mensagem aparece apenas uma vez.",
+    banner_open: "Abrir o Trustpilot",
+    banner_dismiss: "Não, obrigado",
+    opens_in_new_tab: "Abre o Trustpilot num novo separador",
+  },
   survey: {
     banner_title: "Ajude a melhorar o Aster Mail",
     banner_message:

--- a/src/lib/i18n/translations/ru.ts
+++ b/src/lib/i18n/translations/ru.ts
@@ -9882,6 +9882,13 @@ export const ru = {
     delete_confirm_title: "Удалить общий ящик",
     access_unavailable: "Этот общий ящик больше недоступен",
   },
+  review_prompt: {
+    banner_message:
+      "Вы можете оставить отзыв об Aster Mail на Trustpilot. Отзывы публичные, и это сообщение показывается только один раз.",
+    banner_open: "Открыть Trustpilot",
+    banner_dismiss: "Не сейчас",
+    opens_in_new_tab: "Открывает Trustpilot в новой вкладке",
+  },
   survey: {
     banner_title: "Помогите улучшить Aster Mail",
     banner_message:

--- a/src/lib/i18n/translations/tr.ts
+++ b/src/lib/i18n/translations/tr.ts
@@ -9628,6 +9628,13 @@ export const tr = {
     delete_confirm_title: "Ortak posta kutusunu sil",
     access_unavailable: "Bu ortak posta kutusu artık kullanılamıyor",
   },
+  review_prompt: {
+    banner_message:
+      "Aster Mail'i Trustpilot'ta değerlendirebilirsiniz. Değerlendirmeler herkese açıktır ve bu bildirimi yalnızca bir kez görürsünüz.",
+    banner_open: "Trustpilot'u aç",
+    banner_dismiss: "Hayır, teşekkürler",
+    opens_in_new_tab: "Trustpilot'u yeni sekmede açar",
+  },
   survey: {
     banner_title: "Aster Mail'i geliştirmemize yardım edin",
     banner_message:

--- a/src/lib/i18n/translations/zh-CN.ts
+++ b/src/lib/i18n/translations/zh-CN.ts
@@ -8590,6 +8590,13 @@ export const zh_CN = {
     delete_confirm_title: "删除共享邮箱",
     access_unavailable: "此共享邮箱已不可用",
   },
+  review_prompt: {
+    banner_message:
+      "你可以在 Trustpilot 上评价 Aster Mail。评价是公开的，此提示只显示一次。",
+    banner_open: "打开 Trustpilot",
+    banner_dismiss: "暂不需要",
+    opens_in_new_tab: "在新标签页中打开 Trustpilot",
+  },
   survey: {
     banner_title: "帮助我们改进 Aster Mail",
     banner_message:

--- a/src/lib/i18n/types.ts
+++ b/src/lib/i18n/types.ts
@@ -57,6 +57,7 @@ export interface TranslationNamespace {
   compose: ComposeTranslations;
   passkeys: PasskeysTranslations;
   shared_mailboxes: SharedMailboxesTranslations;
+  review_prompt: ReviewPromptTranslations;
   survey: SurveyTranslations;
   calendar: CalendarTranslations;
   settings_search: SettingsSearchTranslations;
@@ -8004,6 +8005,13 @@ export interface BadgesTranslations {
   badge_stargazer_description: string;
 }
 
+export interface ReviewPromptTranslations {
+  banner_message: string;
+  banner_open: string;
+  banner_dismiss: string;
+  opens_in_new_tab: string;
+}
+
 export interface SurveyTranslations {
   banner_title: string;
   banner_message: string;
@@ -8072,6 +8080,7 @@ export type TranslationKey =
   | `compose.${keyof ComposeTranslations}`
   | `passkeys.${keyof PasskeysTranslations}`
   | `shared_mailboxes.${keyof SharedMailboxesTranslations}`
+  | `review_prompt.${keyof ReviewPromptTranslations}`
   | `survey.${keyof SurveyTranslations}`
   | `calendar.${keyof CalendarTranslations}`
   | `settings_search.${keyof SettingsSearchTranslations}`;

--- a/src/lib/review_prompt.ts
+++ b/src/lib/review_prompt.ts
@@ -19,7 +19,6 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
 import { ignore_error } from "@/lib/ignore_error";
-import { get_current_account_id } from "@/services/account_manager";
 
 export const REVIEW_PROMPT_URL =
   "https://www.trustpilot.com/evaluate/astermail.org";
@@ -34,6 +33,10 @@ const DELAY_MS = 3 * 24 * 60 * 60 * 1000;
 
 async function account_scope(): Promise<string> {
   try {
+    const { get_current_account_id } = await import(
+      "@/services/account_manager"
+    );
+
     return (await get_current_account_id()) ?? "default";
   } catch {
     return "default";

--- a/src/lib/review_prompt.ts
+++ b/src/lib/review_prompt.ts
@@ -19,6 +19,7 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 //
 import { ignore_error } from "@/lib/ignore_error";
+import { get_current_account_id } from "@/services/account_manager";
 
 export const REVIEW_PROMPT_URL =
   "https://www.trustpilot.com/evaluate/astermail.org";
@@ -30,6 +31,14 @@ const FORCE_KEY = "aster_review_prompt_force";
 
 const REQUIRED_SENDS = 5;
 const DELAY_MS = 3 * 24 * 60 * 60 * 1000;
+
+async function account_scope(): Promise<string> {
+  try {
+    return (await get_current_account_id()) ?? "default";
+  } catch {
+    return "default";
+  }
+}
 
 function read(key: string): string | null {
   try {
@@ -47,25 +56,32 @@ function write(key: string, value: string) {
   }
 }
 
-export function mark_review_prompt_done() {
-  write(DONE_KEY, "true");
+export async function mark_review_prompt_done() {
+  write(`${DONE_KEY}:${await account_scope()}`, "true");
 }
 
-export function record_review_prompt_action() {
-  if (read(DONE_KEY) === "true" || read(ELIGIBLE_KEY)) return;
+export async function record_review_prompt_action() {
+  const scope = await account_scope();
 
-  const next = Number(read(SENDS_KEY) ?? "0") + 1;
+  if (read(`${DONE_KEY}:${scope}`) === "true") return;
+  if (read(`${ELIGIBLE_KEY}:${scope}`)) return;
 
-  write(SENDS_KEY, String(next));
+  const next = Number(read(`${SENDS_KEY}:${scope}`) ?? "0") + 1;
 
-  if (next >= REQUIRED_SENDS) write(ELIGIBLE_KEY, String(Date.now()));
+  write(`${SENDS_KEY}:${scope}`, String(next));
+
+  if (next >= REQUIRED_SENDS) {
+    write(`${ELIGIBLE_KEY}:${scope}`, String(Date.now()));
+  }
 }
 
-export function should_show_review_prompt(): boolean {
-  if (read(DONE_KEY) === "true") return false;
+export async function is_review_prompt_due(): Promise<boolean> {
+  const scope = await account_scope();
+
+  if (read(`${DONE_KEY}:${scope}`) === "true") return false;
   if (read(FORCE_KEY) === "true") return true;
 
-  const eligible_at = Number(read(ELIGIBLE_KEY) ?? "0");
+  const eligible_at = Number(read(`${ELIGIBLE_KEY}:${scope}`) ?? "0");
 
   return eligible_at > 0 && Date.now() - eligible_at >= DELAY_MS;
 }

--- a/src/lib/review_prompt.ts
+++ b/src/lib/review_prompt.ts
@@ -1,0 +1,71 @@
+//
+// Aster Communications Inc.
+//
+// Copyright (c) 2026 Aster Communications Inc.
+//
+// This file is part of this project.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the AGPLv3 as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// AGPLv3 for more details.
+//
+// You should have received a copy of the AGPLv3
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+import { ignore_error } from "@/lib/ignore_error";
+
+export const REVIEW_PROMPT_URL =
+  "https://www.trustpilot.com/evaluate/astermail.org";
+
+const ELIGIBLE_KEY = "aster_review_prompt_eligible_at";
+const DONE_KEY = "aster_review_prompt_done";
+const SENDS_KEY = "aster_review_prompt_sends";
+const FORCE_KEY = "aster_review_prompt_force";
+
+const REQUIRED_SENDS = 5;
+const DELAY_MS = 3 * 24 * 60 * 60 * 1000;
+
+function read(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: string) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (caught) {
+    ignore_error("lib/review_prompt:write", caught);
+  }
+}
+
+export function mark_review_prompt_done() {
+  write(DONE_KEY, "true");
+}
+
+export function record_review_prompt_action() {
+  if (read(DONE_KEY) === "true" || read(ELIGIBLE_KEY)) return;
+
+  const next = Number(read(SENDS_KEY) ?? "0") + 1;
+
+  write(SENDS_KEY, String(next));
+
+  if (next >= REQUIRED_SENDS) write(ELIGIBLE_KEY, String(Date.now()));
+}
+
+export function should_show_review_prompt(): boolean {
+  if (read(DONE_KEY) === "true") return false;
+  if (read(FORCE_KEY) === "true") return true;
+
+  const eligible_at = Number(read(ELIGIBLE_KEY) ?? "0");
+
+  return eligible_at > 0 && Date.now() - eligible_at >= DELAY_MS;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -136,6 +136,7 @@ export default function IndexPage() {
   const navigate = useNavigate();
   const { section } = useParams<{ section?: string }>();
   const [is_quick_settings_open, set_is_quick_settings_open] = useState(false);
+  const [is_survey_visible, set_is_survey_visible] = useState(false);
   const [first_run_setup_done, set_first_run_setup_done] = useState(
     () => !is_first_run_setup_pending(),
   );
@@ -362,8 +363,10 @@ export default function IndexPage() {
         ) : (
           <NotificationBanner />
         )}
-        <SurveyBanner />
-        <ReviewPromptBanner />
+        <SurveyBanner on_visibility_change={set_is_survey_visible} />
+        {!is_survey_visible && !payment_past_due.is_past_due && (
+          <ReviewPromptBanner />
+        )}
         <TopBar
           is_settings_view={state.is_settings_route && !settings_popup_mode}
           on_mobile_menu_toggle={handle_mobile_menu_toggle}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,6 +105,7 @@ import { NotificationBanner } from "@/components/common/notification_banner";
 import { PaymentPastDueBanner } from "@/components/common/payment_past_due_banner";
 import { use_payment_past_due } from "@/hooks/use_payment_past_due";
 import { SurveyBanner } from "@/components/survey/survey_banner";
+import { ReviewPromptBanner } from "@/components/review/review_prompt_banner";
 import { OnboardingChecklist } from "@/components/onboarding/onboarding_checklist";
 import { FirstRunSetup } from "@/components/onboarding/first_run_setup";
 import { RecoveryReminder } from "@/components/onboarding/recovery_reminder";
@@ -362,6 +363,7 @@ export default function IndexPage() {
           <NotificationBanner />
         )}
         <SurveyBanner />
+        <ReviewPromptBanner />
         <TopBar
           is_settings_view={state.is_settings_route && !settings_popup_mode}
           on_mobile_menu_toggle={handle_mobile_menu_toggle}

--- a/src/services/api/preferences.ts
+++ b/src/services/api/preferences.ts
@@ -78,6 +78,8 @@ export interface UserPreferences {
   quiet_hours_end: string;
   two_factor_auth: boolean;
   show_read_receipts: boolean;
+  review_prompt_web_done: boolean;
+  review_prompt_android_done: boolean;
   send_read_receipts: boolean;
   block_external_images: boolean;
   encrypt_emails: boolean;
@@ -503,6 +505,8 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   quiet_hours_end: "07:00",
   two_factor_auth: true,
   show_read_receipts: false,
+  review_prompt_web_done: false,
+  review_prompt_android_done: false,
   send_read_receipts: false,
   block_external_images: false,
   encrypt_emails: false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -112,6 +112,78 @@ const css_targets = browserslistToTargets(
   browserslist("chrome >= 100, edge >= 100, firefox >= 100, safari >= 15"),
 );
 
+const pwa_manifest = {
+  name: "AsterMail",
+  short_name: "AsterMail",
+  description: "Secure, private email for everyone.",
+  theme_color: "#ffffff",
+  background_color: "#ffffff",
+  display: "standalone",
+  scope: "/",
+  start_url: "/",
+  orientation: "portrait-primary",
+  categories: ["email", "productivity", "security"],
+  icons: [
+    {
+      src: "/pwa-192x192.png",
+      sizes: "192x192",
+      type: "image/png",
+      purpose: "any",
+    },
+    {
+      src: "/pwa-512x512.png",
+      sizes: "512x512",
+      type: "image/png",
+      purpose: "any",
+    },
+    {
+      src: "/pwa-512x512.png",
+      sizes: "512x512",
+      type: "image/png",
+      purpose: "maskable",
+    },
+    {
+      src: "/apple-touch-icon.png",
+      sizes: "180x180",
+      type: "image/png",
+      purpose: "any",
+    },
+  ],
+  shortcuts: [
+    {
+      name: "Compose Email",
+      short_name: "Compose",
+      url: "/?compose=true",
+      icons: [{ src: "/pwa-192x192.png", sizes: "192x192" }],
+    },
+    {
+      name: "Inbox",
+      short_name: "Inbox",
+      url: "/",
+      icons: [{ src: "/pwa-192x192.png", sizes: "192x192" }],
+    },
+  ],
+};
+
+const pwa_manifest_path = "/manifest.webmanifest";
+
+function dev_manifest_plugin(): Plugin {
+  return {
+    name: "dev-manifest",
+    apply: "serve",
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url || req.url.split("?")[0] !== pwa_manifest_path)
+          return next();
+
+        res.setHeader("Content-Type", "application/manifest+json");
+        res.setHeader("Cache-Control", "no-cache");
+        res.end(JSON.stringify(pwa_manifest));
+      });
+    },
+  };
+}
+
 export default defineConfig({
   base: "/",
   resolve: {
@@ -191,6 +263,7 @@ export default defineConfig({
   },
   plugins: [
     version_manifest_plugin(pkg.version, build_hash),
+    dev_manifest_plugin(),
     source_map_fix_plugin(),
     react(),
     tsconfigPaths(),
@@ -208,58 +281,7 @@ export default defineConfig({
         "mail_logo.png",
         "text_logo.png",
       ],
-      manifest: {
-        name: "AsterMail",
-        short_name: "AsterMail",
-        description: "Secure, private email for everyone.",
-        theme_color: "#ffffff",
-        background_color: "#ffffff",
-        display: "standalone",
-        scope: "/",
-        start_url: "/",
-        orientation: "portrait-primary",
-        categories: ["email", "productivity", "security"],
-        icons: [
-          {
-            src: "/pwa-192x192.png",
-            sizes: "192x192",
-            type: "image/png",
-            purpose: "any",
-          },
-          {
-            src: "/pwa-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "any",
-          },
-          {
-            src: "/pwa-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
-          },
-          {
-            src: "/apple-touch-icon.png",
-            sizes: "180x180",
-            type: "image/png",
-            purpose: "any",
-          },
-        ],
-        shortcuts: [
-          {
-            name: "Compose Email",
-            short_name: "Compose",
-            url: "/?compose=true",
-            icons: [{ src: "/pwa-192x192.png", sizes: "192x192" }],
-          },
-          {
-            name: "Inbox",
-            short_name: "Inbox",
-            url: "/",
-            icons: [{ src: "/pwa-192x192.png", sizes: "192x192" }],
-          },
-        ],
-      },
+      manifest: pwa_manifest,
       injectManifest: {
         injectionPoint: undefined,
         globPatterns: [],


### PR DESCRIPTION
Adds a one-time review invitation to the web client, and fixes two problems found while testing it.

## Review prompt

A dismissible banner appears once per browser after five completed sends plus a three day wait, and never again after that.

- The trigger is a send completing, not a judgment about how the person felt. Everyone who meets the criteria sees it, which is what Trustpilot's guidelines and the FTC's rules on review solicitation require.
- No incentive is offered, and the banner says that reviews are public and that the link opens a new tab.
- State lives in `localStorage` only. There are no network calls, no analytics, and no backend column. Dismissal is permanent and the developer override cannot undo it.
- The link opens with `noopener,noreferrer`, so no referrer reaches Trustpilot. No Trustpilot widget or script is embedded, which keeps Aster out of publisher duties under the UK DMCC Act.

The first pass wired only three of the seven send-completion points in `compose_send_actions.ts`. It missed the `on_sent` callbacks, which are where the undo-send queue finishes, so anyone with undo-send on would never have reached the threshold. The trigger now covers all ten completion points across compose, reply, and forward.

Strings are added in all 15 locales.

## Web manifest

`/manifest.webmanifest` fell through to the SPA rewrite in development, so the browser parsed `<!doctype html>` as JSON and logged `Manifest: Line: 1, column: 1, Syntax error` on every load. A dev-only middleware now serves it from the same definition the build uses, so the two cannot drift.

In production nginx served it as `application/octet-stream`, because the stock `mime.types` in nginx 1.27 has no `webmanifest` entry and `X-Content-Type-Options: nosniff` then rejects it. The image adds the entry when it is missing.

## Recovery reminder

The tinted circle badge is replaced with an inline key icon on the heading's baseline.

## Verification

- `tsc --noEmit` clean for the changed files
- `vitest run src/lib/i18n`: 89 tests across 7 files pass
- `npm run build` exits 0; `dist/manifest.webmanifest` is valid JSON with 4 icons and 2 shortcuts
- No stale `localhost:<port>` URLs and no test keys in `dist`
- Prettier clean

The Android half is Aster-Privacy/Aster-Android#43.


## Update: the prompt is scoped to the account

State moved out of `localStorage` and into the account's encrypted preferences vault, under `review_prompt_web_done`. The vault is encrypted client-side and the server only ever stores ciphertext, so each account is asked once across every browser it signs into, and the server never learns that a review was requested. No migration and no backend change are needed.

Web and Android carry separate flags, so each platform asks once for its own store. Android preserves unknown preference keys on save, so neither client clobbers the other's flag. The send counter stays in `localStorage`, keyed by account, so two accounts in one browser no longer share a counter.

A local `done` marker is still written as an offline fallback, so a failed sync cannot bring the banner back.

## Also fixed

- The banner rendered alongside the survey banner and under the past due notice, which asked for a public review while telling someone their payment had failed. It now yields to both.
